### PR TITLE
Feature/toggle chapter and section prefixes visibility

### DIFF
--- a/classes/local/utils.php
+++ b/classes/local/utils.php
@@ -14,79 +14,81 @@ use xmldb_table;
 defined('MOODLE_INTERNAL') || die();
 
 class utils {
-   
+
     public static function complete_section($section) {
         global $USER;
-        set_user_preference('format_mooin4_section_completed_'.$section, 1, $USER->id);
+        set_user_preference('format_mooin4_section_completed_' . $section, 1, $USER->id);
     }
 
     public static function is_course_completed($course_id) {
         global $DB;
         $is_course_completed = false;
         if ($course_chapters = $DB->get_records('format_mooin4_chapter', array('courseid' => $course_id))) {
-          $is_course_completed = true;
-          foreach ($course_chapters as $chapter) {
-            $chapter_info = self::get_chapter_info($chapter);
-            if ($chapter_info['completed'] == false) {
-              $is_course_completed = false;
-              return false;
+            $is_course_completed = true;
+            foreach ($course_chapters as $chapter) {
+                $chapter_info = self::get_chapter_info($chapter);
+                if ($chapter_info['completed'] == false) {
+                    $is_course_completed = false;
+                    return false;
+                }
             }
-          }
         }
         return $is_course_completed;
     }
 
     public static function get_course_progress($courseid, $userid) {
         global $DB;
-    
+
         $percentage = 0;
         $i = 0;
         if ($sections = $DB->get_records('course_sections', array('course' => $courseid))) {
             foreach ($sections as $section) {
-                if (!$DB->get_record('format_mooin4_chapter', array('sectionid' => $section->id)) &&
-                        $section->section != 0) {
+                if (
+                    !$DB->get_record('format_mooin4_chapter', array('sectionid' => $section->id)) &&
+                    $section->section != 0
+                ) {
                     $i++;
                     $percentage += self::get_section_progress($courseid, $section->id, $userid);
                 }
             }
         }
-    
+
         if ($percentage > 0) {
             $percentage = $percentage / $i;
         }
-    
+
         return round($percentage);
     }
 
-    
+
     public static function setgrade($contextid, $score, $maxscore) {
         global $DB, $USER, $CFG;
         require_once($CFG->dirroot . '/mod/hvp/lib.php');
-        
-        
-    
+
+
+
         $cm = get_coursemodule_from_instance('hvp', $contextid);
         if (!$cm) {
             return false;
         }
-    
+
         // Check permission.
         $context = \context_module::instance($cm->id);
         if (!has_capability('mod/hvp:saveresults', $context)) {
             return false;
         }
-    
+
         // Get hvp data from content.
         $hvp = $DB->get_record('hvp', array('id' => $cm->instance));
         if (!$hvp) {
             return false;
         }
-    
+
         // Create grade object and set grades.
         $grade = (object)array(
             'userid' => $USER->id
         );
-    
+
         /* oncampus mod - start */
         require_once($CFG->libdir . '/gradelib.php');
         $grading_info = \grade_get_grades($cm->course, 'mod', 'hvp', $cm->instance, $USER->id);
@@ -96,16 +98,16 @@ class utils {
         } else {
             $user_grade = 0;
         }
-    
+
         if ($score >= $user_grade) {
-            
+
             // Set grade using Gradebook API.
             $hvp->cmidnumber = $cm->idnumber;
             $hvp->name = $cm->name;
             $hvp->rawgrade = $score;
             $hvp->rawgrademax = $maxscore;
             hvp_grade_item_update($hvp, $grade);
-    
+
             // Get content info for log.
             $content = $DB->get_record_sql(
                 "SELECT c.name AS title, l.machine_name AS name, l.major_version, l.minor_version
@@ -114,14 +116,17 @@ class utils {
                           WHERE c.id = ?",
                 array($hvp->id)
             );
-    
+
             // Log results set event.
             new \mod_hvp\event(
-                'results', 'set',
-                $hvp->id, $content->title,
-                $content->name, $content->major_version . '.' . $content->minor_version
+                'results',
+                'set',
+                $hvp->id,
+                $content->title,
+                $content->name,
+                $content->major_version . '.' . $content->minor_version
             );
-    
+
             // $progress = get_progress($cm->course, $cm->section);
             $progress = self::get_hvp_section_progress($cm->course, $cm->section, $USER->id);
             /* <script>;
@@ -134,37 +139,39 @@ class utils {
                 $('#' + divId, window.parent.document).css('width', percentageInt);
                 $('#' + textDivId, window.parent.document).html(percentageText);
             </script>; */
-    
+
             return $progress;
         }
-        
+
         return false;
     }
 
     public static function get_hvp_section_progress($courseid, $sectionid, $userid) {
         global $DB, $CFG;
-    
+
         require_once($CFG->libdir . '/gradelib.php');
-    
+
         $percentage = 0;
-    
+
         // no activities in this section?
-        $coursemodules = $DB->get_records('course_modules', array('course' => $courseid,
-                                                                       'deletioninprogress' => 0,
-                                                                       'section' => $sectionid));
-    
+        $coursemodules = $DB->get_records('course_modules', array(
+            'course' => $courseid,
+            'deletioninprogress' => 0,
+            'section' => $sectionid
+        ));
+
         $activities = 0;
-    
+
         foreach ($coursemodules as $coursemodule) {
             // cm has completion activated?
             if ($coursemodule->completion == 2) {
                 $activities++;
-    
+
                 $modulename = '';
                 if ($module = $DB->get_record('modules', array('id' => $coursemodule->module))) {
                     $modulename = $module->name;
                 }
-    
+
                 // activity is hvp, we use the grades to get the individual progress
                 if ($modulename == 'hvp') {
                     $grading_info = grade_get_grades($courseid, 'mod', 'hvp', $coursemodule->instance, $userid);
@@ -173,34 +180,34 @@ class utils {
                     if (isset($grade) && $grade != 0) {
                         $percentage += 100 / ($grademax / $grade);
                     }
-                }
-                else {
+                } else {
                     // if completed, add to percentage
                     $sql = 'SELECT *
                               FROM {course_modules_completion}
                              WHERE coursemoduleid = :coursemoduleid
                                AND userid = :userid
                                AND completionstate != 0 ';
-                    $params = array('coursemoduleid' => $coursemodule->id,
-                                    'userid' => $userid);
+                    $params = array(
+                        'coursemoduleid' => $coursemodule->id,
+                        'userid' => $userid
+                    );
                     if ($DB->get_record_sql($sql, $params)) {
                         $percentage += 100;
                     }
                 }
             }
         }
-    
+
         // no activities with completion activated?
         if ($activities == 0) {
-            if (get_user_preferences('format_mooin4_section_completed_'.$sectionid, 0, $userid) == 1) {
+            if (get_user_preferences('format_mooin4_section_completed_' . $sectionid, 0, $userid) == 1) {
                 return 100;
-            }
-            else {
+            } else {
                 return 0;
             }
         }
         $progress = array('sectionid' => $sectionid, 'percentage' => round($percentage / $activities));
-        return $progress;// round($percentage / $activities);
+        return $progress; // round($percentage / $activities);
     }
 
     public static function set_user_coordinates($userid, $lat, $lng) {
@@ -289,7 +296,7 @@ class utils {
         return $templatecontext;
     }
 
-     /**
+    /**
      * Get the last News in the course
      * @param int $courseid
      * @param string $forum_type
@@ -368,7 +375,7 @@ class utils {
 
     public static function count_unread_posts($userid, $courseid, $news = false, $forumid = 0) {
         global $DB, $USER;
-    
+
         // SQL query to get all unread posts
         $sql = 'SELECT fp.*, f.id as forumid, fd.groupid, fd.id as discussionid, cm.id as cmid
                 FROM {forum_posts} as fp
@@ -378,7 +385,7 @@ class utils {
                 WHERE f.course = :courseid
                 AND cm.visible = 1
                 AND (fp.mailnow = 1 OR fp.created < :wait) ';
-        
+
         if ($forumid > 0) {
             $sql .= 'AND f.id = :forumid ';
         } else if ($news) {
@@ -386,9 +393,9 @@ class utils {
         } else {
             $sql .= 'AND f.type != :news ';
         }
-    
+
         $sql .= 'AND fp.id NOT IN (SELECT postid FROM {forum_read} WHERE userid = :userid)';
-    
+
         $params = array(
             'courseid' => $courseid,
             'news' => 'news',
@@ -396,24 +403,24 @@ class utils {
             'forumid' => $forumid,
             'wait' => time() - 1800
         );
-    
+
         $unreadposts = $DB->get_records_sql($sql, $params);
         $visible_unread_posts = 0;
-    
+
         // Check visibility of each post
         foreach ($unreadposts as $post) {
             $forum = $DB->get_record('forum', array('id' => $post->forumid));
             $discussion = $DB->get_record('forum_discussions', array('id' => $post->discussionid));
             $cm = get_coursemodule_from_instance('forum', $forum->id, $courseid);
-    
+
             if (forum_user_can_see_post($forum, $discussion, $post, $USER, $cm)) {
                 $visible_unread_posts++;
             }
         }
-    
+
         return $visible_unread_posts;
     }
-    
+
 
     /**
      * Get the last forum discussion in the course
@@ -423,7 +430,7 @@ class utils {
      */
     public static function get_last_forum_discussion($courseid, $forum_type) {
         global $DB, $OUTPUT, $USER;
-    
+
         $sql = 'SELECT fp.*, f.id as forumid, fd.groupid, fd.id as discussionid, cm.id as cmid
                 FROM {forum_posts} as fp
                 JOIN {forum_discussions} as fd ON fp.discussion = fd.id
@@ -434,26 +441,26 @@ class utils {
                 AND f.type != :news
                 AND cm.module = (SELECT id FROM {modules} WHERE name = "forum")
                 ORDER BY fp.created DESC';
-    
+
         $params = array(
             'courseid' => $courseid,
             'news' => 'news',
             'wait' => time() - 1800
         );
-    
+
         $latestposts = $DB->get_records_sql($sql, $params);
-    
+
         if (!empty($latestposts)) {
             foreach ($latestposts as $post) {
                 $forum = $DB->get_record('forum', array('id' => $post->forumid));
                 $discussion = $DB->get_record('forum_discussions', array('id' => $post->discussionid));
                 $cm = get_coursemodule_from_instance('forum', $forum->id, $courseid);
-    
+
                 if (forum_user_can_see_post($forum, $discussion, $post, $USER, $cm)) {
                     $user = $DB->get_record('user', ['id' => $post->userid], '*');
                     $created_news = date("d.m.Y, G:i", date((int)$post->created));
                     $unread_forum_number = self::count_unread_posts($USER->id, $courseid, false);
-    
+
                     $forum_discussion_url = new moodle_url('/mod/forum/discuss.php', array('d' => $post->discussion));
                     $templatecontext = [
                         'user_firstname' =>  $user->firstname,
@@ -470,7 +477,7 @@ class utils {
                 }
             }
         }
-    
+
         // Default context if no posts are found or accessible
         $templatecontext = [
             'unread_news_number' => 0,
@@ -478,12 +485,12 @@ class utils {
             'no_news' => false,
             'new_news' => false
         ];
-    
+
         return $templatecontext;
     }
-    
-    
-    
+
+
+
 
     /**
      * Get the right user picture for creating forum
@@ -516,13 +523,15 @@ class utils {
 
     public static function set_discussion_viewed($userid, $forumid, $discussionid) {
         global $DB;
-    
+
         $posts = $DB->get_records('forum_posts', array('discussion' => $discussionid));
         foreach ($posts as $post) {
-            if (!$read = $DB->get_record('forum_read', array('userid' => $userid,
-                                                             'forumid' => $forumid,
-                                                             'discussionid' => $discussionid,
-                                                             'postid' => $post->id))) {
+            if (!$read = $DB->get_record('forum_read', array(
+                'userid' => $userid,
+                'forumid' => $forumid,
+                'discussionid' => $discussionid,
+                'postid' => $post->id
+            ))) {
                 $read = new stdClass();
                 $read->userid = $userid;
                 $read->forumid = $forumid;
@@ -537,35 +546,34 @@ class utils {
 
     public static function set_chapter($sectionid) {
         global $DB;
-    
+
         if ($DB->get_record('format_mooin4_chapter', array('sectionid' => $sectionid))) {
             return;
         }
-    
+
         if ($csection = $DB->get_record('course_sections', array('id' => $sectionid))) {
             $csectiontitle = $csection->name;
-        }
-        else {
+        } else {
             return;
         }
-    
+
         if (!$csectiontitle) {
             $csectiontitle = get_string('new_chapter', 'format_mooin4');
         }
-    
+
         $chapter = new stdClass();
         $chapter->courseid = $csection->course;
         $chapter->title = $csectiontitle;
         $chapter->sectionid = $sectionid;
         $chapter->chapter = 0;
         $DB->insert_record('format_mooin4_chapter', $chapter);
-    
+
         self::sort_course_chapters($csection->course);
     }
 
     public static function unset_chapter($sectionid) {
         global $DB;
-    
+
         $DB->delete_records('format_mooin4_chapter', array('sectionid' => $sectionid));
         if ($csection = $DB->get_record('course_sections', array('id' => $sectionid))) {
             self::sort_course_chapters($csection->course);
@@ -587,77 +595,86 @@ class utils {
 
     public static function get_last_section($courseid) {
         global $DB;
-    
+
         $lastsection = 0;
         $count = $DB->count_records('course_sections', array('course' => $courseid));
-    
+
         if ($count > 0) {
             $lastsection = $count - 1;
         }
-    
+
         return $lastsection;
     }
-    
-    
-    
+
+
+
     public static function get_section_prefix($section) {
         global $DB, $USER;
-    
+
         $sectionprefix = '';
-    
+
         // Get parent chapter of the section
         $parentchapter = self::get_parent_chapter($section);
         if (is_object($parentchapter)) {
             // Get section ids for the chapter
             $sids = self::get_sectionids_for_chapter($parentchapter->id);
-    
+
             // Get the course and format
             $course = get_course($section->course);
             $format = course_get_format($course);
             $modinfo = get_fast_modinfo($course, $USER->id);
             $context = context_course::instance($course->id);
-    
+
             $visible_count = 0;
-    
-            foreach ($sids as $sid) {
-                $section_info = $modinfo->get_section_info_by_id($sid);
-                $is_visible = ($section_info && $format->is_section_visible($section_info));
-    
-                if ($sid == $section->id) {
-                    if (!$section->visible) {
-                        $sectionprefix = 'ausgeblendet';
-                    } else {
-                        $visible_count += 1;
-                        $sectionprefix = $parentchapter->chapter . '.' . $visible_count;
+
+            require_once(__DIR__ . '/../../lib.php');
+            $courseid = $course->id;
+            //calc lesson numbers only if nessessary
+            if (get_toggle_section_number_visibility($courseid) === 1) {
+
+                foreach ($sids as $sid) {
+                    $section_info = $modinfo->get_section_info_by_id($sid);
+                    $is_visible = ($section_info && $format->is_section_visible($section_info));
+
+                    if ($sid == $section->id) {
+                        if (!$section->visible) {
+                            $sectionprefix = 'ausgeblendet';
+                        } else {
+                            $visible_count += 1;
+                            $sectionprefix = $parentchapter->chapter . '.' . $visible_count;
+                        }
+                        break;
                     }
-                    break;
+
+
+                    if ($is_visible && $section_info->visible) {
+                        $visible_count += 1;
+                        error_log($section->name . $visible_count);
+                    }
                 }
-    
-                
-                if ($is_visible && $section_info->visible) {
-                    $visible_count += 1;
-                    error_log($section->name.$visible_count);
-                }
+            } else {
+                $sectionprefix = '';
             }
         }
-    
         return $sectionprefix;
     }
-    
-    
-    
-    
+
+
+
+
+
+
     // public static function get_section_prefix($section) {
     //     global $DB, $USER;
-    
+
     //     $sectionprefix = '';
-    
+
     //     // Get parent chapter of the section
     //     $parentchapter = self::get_parent_chapter($section);
     //     if (is_object($parentchapter)) {
     //         // Get section ids for the chapter
     //         $sids = self::get_sectionids_for_chapter($parentchapter->id);
-    
+
     //         // Filter sids array to include only visible sections
     //         $visible_sids = array_filter($sids, function($sid) use ($DB, $USER) {
     //             $course_section = $DB->get_record('course_sections', array('id' => $sid));
@@ -670,10 +687,10 @@ class utils {
     //             }
     //             return false;
     //         });
-    
+
     //         // Re-index the array to ensure keys are sequential
     //         $visible_sids = array_values($visible_sids);
-    
+
     //         // Find the index of the current section in the filtered array
     //         $index = array_search($section->id, $visible_sids);
     //         if ($index !== false) {
@@ -683,33 +700,33 @@ class utils {
     //     }
     //     return $sectionprefix;
     // }
-    
-    
+
+
 
     // public static function get_section_prefix($section) {
     //     global $DB;
-    
+
     //     $sectionprefix = '';
-    
+
     //     $parentchapter = self::get_parent_chapter($section);
     //     if (is_object($parentchapter)) {
     //         $sids = self::get_sectionids_for_chapter($parentchapter->id);
     //         $sectionprefix .= $parentchapter->chapter.'.'.(array_search($section->id, $sids) + 1);
-    
+
     //         return $sectionprefix;
     //     }
-    
+
     // }
 
-    
-    
-    
-    
-    
+
+
+
+
+
 
     public static function get_parent_chapter($section) {
         global $DB;
-    
+
         $chapters = $DB->get_records('format_mooin4_chapter', array('courseid' => $section->course));
         foreach ($chapters as $chapter) {
             $sids = self::get_sectionids_for_chapter($chapter->id);
@@ -717,7 +734,7 @@ class utils {
                 return $chapter;
             }
         }
-    
+
         return false;
     }
 
@@ -735,8 +752,7 @@ class utils {
                                 AND cs.section < :nextchaptersection;';
                         $params = array('courseid' => $chapter->courseid, 'chaptersection' => $chaptersection->section, 'nextchaptersection' => $nextchaptersection->section);
                     }
-                }   
-                else {
+                } else {
                     $sql = 'SELECT cs.id 
                             FROM {course_sections} cs
                             WHERE cs.course = :courseid
@@ -751,66 +767,66 @@ class utils {
 
     public static function get_course_chapters($courseid) {
         global $DB;
-    
+
         $sql = 'SELECT c.*, s.section
                   FROM {format_mooin4_chapter} as c, {course_sections} as s
                  WHERE s.course = :courseid
                    and s.id = c.sectionid
               order by s.section asc';
-    
+
         $params = array('courseid' => $courseid);
-    
+
         $coursechapters = $DB->get_records_sql($sql, $params);
-    
+
         return $coursechapters;
     }
 
     public static function is_first_section_of_chapter($sectionid) {
         global $DB;
-    
-        
+
+
         if ($section = $DB->get_record('course_sections', array('id' => $sectionid))) {
-            
+
             $chapters = self::get_course_chapters($section->course);
 
             $course = get_course($section->course);
             $format = course_get_format($course);
-    
-           
+
+
             foreach ($chapters as $c) {
-                
+
                 $next_sections = $DB->get_records_sql(
                     "SELECT * FROM {course_sections}
                      WHERE course = :courseid AND section > :chaptersection
                      ORDER BY section ASC",
                     array('courseid' => $section->course, 'chaptersection' => $c->section)
                 );
-    
-                
+
+
                 foreach ($next_sections as $next_section) {
                     $section_info = get_fast_modinfo($course)->get_section_info($next_section->section);
                     if ($format->is_section_visible($section_info)) {
-                        
+
                         if ($next_section->id == $sectionid) {
                             return true;
                         }
-                        break; 
+                        break;
                     }
                 }
             }
         }
         return false;
     }
-    
-    
+
+
     // public static function is_last_section_of_chapter($sectionid) {
     //     global $DB;
     //     $chapter = null;
     //     if ($section = $DB->get_record('course_sections', array('id' => $sectionid))) {
-    
+
     //         $chapters = self::get_course_chapters($section->course);
     //         $chapter = self::get_chapter_for_section($sectionid);
-    
+
     //         $start = 0;
     //         $end = 0;
     //         foreach ($chapters as $c) {
@@ -828,7 +844,7 @@ class utils {
     //                 $end = self::get_last_section($section->course) + 1;
     //             }
     //         }
-    
+
     //         if ($section -> section == $end-1) {
     //             return true;
     //         }
@@ -839,7 +855,7 @@ class utils {
     //TODO: Funktioniert -> evtl gut falls sections doch unsichtbar gemacht werden sollen, aber erstmal sections stattdessen sperren
     public static function is_last_section_of_chapter($sectionid) {
         global $DB;
-        
+
         if ($section = $DB->get_record('course_sections', array('id' => $sectionid))) {
             $course = get_course($section->course);
             $format = course_get_format($course);
@@ -864,9 +880,9 @@ class utils {
         $chapter = null;
         if ($section = $DB->get_record('course_sections', array('id' => $sectionid))) {
             $chapters = self::get_course_chapters($section->course);
-    
+
             foreach ($chapters as $c) {
-                if ($section->section > $c->section && ($chapter = null||$c->section > $chapter)) {
+                if ($section->section > $c->section && ($chapter = null || $c->section > $chapter)) {
                     $chapter = $c->chapter;
                 }
             }
@@ -876,77 +892,77 @@ class utils {
 
     public static function course_navbar() {
         global $PAGE, $OUTPUT, $COURSE;
-         $items = $PAGE->navbar->get_items();
-         $course_items = [];
-    
+        $items = $PAGE->navbar->get_items();
+        $course_items = [];
+
         //Split the navbar array at coursehome
-         foreach($items as $item) {
+        foreach ($items as $item) {
             if ($item->key === $COURSE->id) {
                 $course_items = array_splice($items, intval(array_search($item, $items)));
             }
-         }
-    
-         $course_items[0]->add_class('course-title');
-         $course_items[0]->text = $COURSE->fullname;
-         $section_node = $course_items[array_key_last($course_items)];
-         $section_node->action = null;
-         $text = $section_node->text;
-         $parts = explode(':', $text, 2);
-         $result = trim($parts[0]) . ':';
-         $text = $section_node->text = $result;
-    
-         //Provide custom templatecontext for the new Navbar
+        }
+
+        $course_items[0]->add_class('course-title');
+        $course_items[0]->text = $COURSE->fullname;
+        $section_node = $course_items[array_key_last($course_items)];
+        $section_node->action = null;
+        $text = $section_node->text;
+        $parts = explode(':', $text, 2);
+        $result = trim($parts[0]) . ':';
+        $text = $section_node->text = $result;
+
+        //Provide custom templatecontext for the new Navbar
         $templatecontext = array(
-            'get_items'=> $course_items
+            'get_items' => $course_items
         );
-    
+
         return $OUTPUT->render_from_template('format_mooin4/custom_navbar', $templatecontext);
     }
 
     public static function subpage_navbar() {
         global $PAGE, $OUTPUT, $COURSE;
-         $items = $PAGE->navbar->get_items();
-         $course_items = [];
-    
+        $items = $PAGE->navbar->get_items();
+        $course_items = [];
+
         //Split the navbar array at coursehome
-         foreach($items as $item) {
+        foreach ($items as $item) {
             if ($item->key === $COURSE->id) {
                 $course_items = array_splice($items, intval(array_search($item, $items)));
             }
-         }
-         $course_items[0]->text = $COURSE->fullname;
-    
-         //$course_items[0]->add_class('course-title');
-         $last_node = $course_items[array_key_last($course_items)];
-         $last_node->action = null;
-         $last_node->shorttext = $last_node->text;
-    
-    
-         //Provide custom templatecontext for the new Navbar
+        }
+        $course_items[0]->text = $COURSE->fullname;
+
+        //$course_items[0]->add_class('course-title');
+        $last_node = $course_items[array_key_last($course_items)];
+        $last_node->action = null;
+        $last_node->shorttext = $last_node->text;
+
+
+        //Provide custom templatecontext for the new Navbar
         $templatecontext = array(
-            'get_items'=> $course_items
+            'get_items' => $course_items
         );
-    
+
         return $OUTPUT->render_from_template('format_mooin4/custom_navbar', $templatecontext);
     }
 
     public static function get_chapter_info($chapter) {
         global $USER, $DB;
         $info = array();
-    
+
         $chaptercompleted = false;
         $lastvisited = false;
-    
+
         $sectionids = self::get_sectionids_for_chapter($chapter->id);
         $completedsections = 0;
-    
+
         foreach ($sectionids as $sectionid) {
             $section = $DB->get_record('course_sections', array('id' => $sectionid));
             if ($section && self::is_section_completed($chapter->courseid, $section)) {
                 $completedsections++;
             }
-    
-            $last_section = get_user_preferences('format_mooin4_last_section_in_course_'.$chapter->courseid, 0, $USER->id);
+
+            $last_section = get_user_preferences('format_mooin4_last_section_in_course_' . $chapter->courseid, 0, $USER->id);
             if ($record = $DB->get_record('course_sections', array('course' => $chapter->courseid, 'section' => $last_section))) {
                 if ($record->id == $sectionid) {
                     $lastvisited = true;
@@ -955,7 +971,7 @@ class utils {
         }
         if ($completedsections == count($sectionids)) {
             $chaptercompleted = true;
-        }else {
+        } else {
             $chaptercompleted = false;
         }
         $info['completed'] = $chaptercompleted;
@@ -983,37 +999,39 @@ class utils {
         $result = false;
         if (self::get_section_progress($courseid, $section->id, $USER->id) == 100) {
             $result = true;
-        }else {
+        } else {
             $result = false;
         }
-    
+
         return $result;
     }
 
     public static function get_section_progress($courseid, $sectionid, $userid) {
         global $DB, $CFG;
-    
+
         require_once($CFG->libdir . '/gradelib.php');
-    
+
         $percentage = 0;
-    
+
         // no activities in this section?
-        $coursemodules = $DB->get_records('course_modules', array('course' => $courseid,
-                                                                       'deletioninprogress' => 0,
-                                                                       'section' => $sectionid));
-    
+        $coursemodules = $DB->get_records('course_modules', array(
+            'course' => $courseid,
+            'deletioninprogress' => 0,
+            'section' => $sectionid
+        ));
+
         $activities = 0;
-    
+
         foreach ($coursemodules as $coursemodule) {
             // cm has completion activated?
             if ($coursemodule->completion == 2) {
                 $activities++;
-    
+
                 $modulename = '';
                 if ($module = $DB->get_record('modules', array('id' => $coursemodule->module))) {
                     $modulename = $module->name;
                 }
-    
+
                 // activity is hvp, we use the grades to get the individual progress
                 if ($modulename == 'hvp') {
                     $grading_info = grade_get_grades($courseid, 'mod', 'hvp', $coursemodule->instance, $userid);
@@ -1022,53 +1040,53 @@ class utils {
                     if (isset($grade) && $grade != 0) {
                         $percentage += 100 / ($grademax / $grade);
                     }
-                }
-                else {
+                } else {
                     // if completed, add to percentage
                     $sql = 'SELECT *
                               FROM {course_modules_completion}
                              WHERE coursemoduleid = :coursemoduleid
                                AND userid = :userid
                                AND completionstate != 0 ';
-                    $params = array('coursemoduleid' => $coursemodule->id,
-                                    'userid' => $userid);
+                    $params = array(
+                        'coursemoduleid' => $coursemodule->id,
+                        'userid' => $userid
+                    );
                     if ($DB->get_record_sql($sql, $params)) {
                         $percentage += 100;
                     }
                 }
             }
         }
-    
+
         // no activities with completion activated?
         if ($activities == 0) {
-            if (get_user_preferences('format_mooin4_section_completed_'.$sectionid, 0, $userid) == 1) {
+            if (get_user_preferences('format_mooin4_section_completed_' . $sectionid, 0, $userid) == 1) {
                 return 100;
-            }
-            else {
+            } else {
                 return 0;
             }
         }
-    
+
         return round($percentage / $activities);
     }
 
     public static function get_unenrol_url($courseid) {
         global $DB, $USER, $CFG;
-    
+
         if ($enrol = $DB->get_record('enrol', array('courseid' => $courseid, 'enrol' => 'autoenrol', 'status' => 0))) {
             if ($user_enrolment = $DB->get_record('user_enrolments', array('enrolid' => $enrol->id, 'userid' => $USER->id))) {
-                $unenrolurl = new moodle_url($CFG->wwwroot.'/enrol/autoenrol/unenrolself.php?enrolid='.$enrol->id);
+                $unenrolurl = new moodle_url($CFG->wwwroot . '/enrol/autoenrol/unenrolself.php?enrolid=' . $enrol->id);
                 return $unenrolurl;
             }
         }
-    
+
         if ($enrol = $DB->get_record('enrol', array('courseid' => $courseid, 'enrol' => 'self', 'status' => 0))) {
             if ($user_enrolment = $DB->get_record('user_enrolments', array('enrolid' => $enrol->id, 'userid' => $USER->id))) {
-                $unenrolurl = new moodle_url($CFG->wwwroot.'/enrol/self/unenrolself.php?enrolid='.$enrol->id);
+                $unenrolurl = new moodle_url($CFG->wwwroot . '/enrol/self/unenrolself.php?enrolid=' . $enrol->id);
                 return $unenrolurl;
             }
         }
-    
+
         return false;
     }
 
@@ -1157,23 +1175,24 @@ class utils {
                    and filearea = :filearea
                    and itemid = :courseid
                    and mimetype like :mimetype';
-    
-        $params = array('contextid' => $context->id,
+
+        $params = array(
+            'contextid' => $context->id,
             'component' => 'format_mooin4',
             'filearea' => $filearea,
             'courseid' => $courseid,
-                        'mimetype' => 'image/%');
-    
+            'mimetype' => 'image/%'
+        );
+
         $records = $DB->get_records_sql($sql, $params);
-    
+
         if (count($records) == 1) {
             $filename = $records[0]->filename;
-        }
-        else {
+        } else {
             return false;
         }
-    
-        $url = new moodle_url('/pluginfile.php/'.$context->id.'/format_mooin4/'.$filearea.'/'.$courseid.'/0/'.$filename);
+
+        $url = new moodle_url('/pluginfile.php/' . $context->id . '/format_mooin4/' . $filearea . '/' . $courseid . '/0/' . $filename);
         return $url;
     }
 
@@ -1268,9 +1287,9 @@ class utils {
         return $certificates;
     }
 
-    
 
-    public static function count_certificate($userid, $courseid){
+
+    public static function count_certificate($userid, $courseid) {
         /* We have to found the certificate module in the DB
             One for ilddigitalcertificate and the other for coursecertificate
         */
@@ -1279,46 +1298,46 @@ class utils {
         $not_completed = 0;
         $result = [];
         // Make the request into the module & course_module
-        $module_ilddigitalcert = $DB->get_record('modules', ['name' =>'ilddigitalcert']);
-        $module_coursecertificate = $DB->get_record('modules', ['name' =>'coursecertificate']);
-    
-        if($module_ilddigitalcert == true) {
+        $module_ilddigitalcert = $DB->get_record('modules', ['name' => 'ilddigitalcert']);
+        $module_coursecertificate = $DB->get_record('modules', ['name' => 'coursecertificate']);
+
+        if ($module_ilddigitalcert == true) {
             // Make request into course_module
-            $cm_ilddigitalcertificate = $DB->get_records('course_modules', ['module' =>$module_ilddigitalcert->id]);
+            $cm_ilddigitalcertificate = $DB->get_records('course_modules', ['module' => $module_ilddigitalcert->id]);
         } else {
             $cm_ilddigitalcertificate  = [];
         }
-        if($module_coursecertificate == true) {
+        if ($module_coursecertificate == true) {
             // Make request into course_module
-            $cm_coursecertificate = $DB->get_records('course_modules', ['module' =>$module_coursecertificate->id]);
+            $cm_coursecertificate = $DB->get_records('course_modules', ['module' => $module_coursecertificate->id]);
         } else {
             $cm_coursecertificate  = [];
         }
-    
+
         // Check if the module has been completed and save into module_completion table
-        if(isset($cm_ilddigitalcertificate)) {
-            foreach($cm_ilddigitalcertificate as $value) {
-                $exist_completed_certificate = $DB->record_exists('course_modules_completion', ['coursemoduleid'=>$value->id, 'userid'=>$userid]);
-                if($exist_completed_certificate) {
+        if (isset($cm_ilddigitalcertificate)) {
+            foreach ($cm_ilddigitalcertificate as $value) {
+                $exist_completed_certificate = $DB->record_exists('course_modules_completion', ['coursemoduleid' => $value->id, 'userid' => $userid]);
+                if ($exist_completed_certificate) {
                     $completed++;
-                }else {
+                } else {
                     $not_completed++;
                 }
             }
         }
-        if(isset($cm_coursecertificate)) {
-            foreach($cm_coursecertificate as $value) {
-                $exist_completed_certificate = $DB->record_exists('course_modules_completion', ['coursemoduleid'=>$value->id, 'userid'=>$userid]);
-                if($exist_completed_certificate) {
+        if (isset($cm_coursecertificate)) {
+            foreach ($cm_coursecertificate as $value) {
+                $exist_completed_certificate = $DB->record_exists('course_modules_completion', ['coursemoduleid' => $value->id, 'userid' => $userid]);
+                if ($exist_completed_certificate) {
                     $completed++;
-                }else {
+                } else {
                     $not_completed++;
                 }
             }
         }
-    
-        $result = ['completed'=>$completed, 'not_completed'=>$not_completed] ;
-    
+
+        $result = ['completed' => $completed, 'not_completed' => $not_completed];
+
         return $result;
     }
 
@@ -1622,7 +1641,7 @@ class utils {
     }
 
     public static function set_new_certificate($awardedtoid, $issuedid, $modulename) {
-        set_user_preference('format_mooin4_new_certificate_'.$modulename.'_'.$issuedid, true, $awardedtoid);
+        set_user_preference('format_mooin4_new_certificate_' . $modulename . '_' . $issuedid, true, $awardedtoid);
     }
 
     public static function unset_new_certificate($viewedbyuserid, $issuedid, $modulename) {
@@ -1630,20 +1649,21 @@ class utils {
         $tablename = 'ilddigitalcert_issued';
         if ($modulename == 'coursecertificate') {
             $tablename = 'tool_certificate_issues';
-        }
-        else if ($modulename == 'ilddigitalcert') {
+        } else if ($modulename == 'ilddigitalcert') {
             $tablename = 'ilddigitalcert_issued';
         }
-        $sql = 'SELECT * from {'.$tablename.'}
+        $sql = 'SELECT * from {' . $tablename . '}
                  WHERE id = :id
                    AND userid = :userid ';
-        $params = array('tablename' => $tablename,
-                        'id' => $issuedid,
-                        'userid' => $viewedbyuserid);
-    
+        $params = array(
+            'tablename' => $tablename,
+            'id' => $issuedid,
+            'userid' => $viewedbyuserid
+        );
+
         if ($record = $DB->get_record_sql($sql, $params)) {
             if ($record->userid == $viewedbyuserid) {
-                unset_user_preference('format_mooin4_new_certificate_'.$modulename.'_'.$record->id, $viewedbyuserid);
+                unset_user_preference('format_mooin4_new_certificate_' . $modulename . '_' . $record->id, $viewedbyuserid);
             }
         }
     }
@@ -1651,68 +1671,68 @@ class utils {
     static function get_user_coordinates($user) {
         if ($user->city != '') {
             $coordinates = new stdClass();
-    
+
             $url = get_config('format_mooin4', 'geonamesapi_url');
             $apiusername = get_config('format_mooin4', 'geonamesapi_username');
-    
-            $response = self::get_url_content($url, "/search?username=".$apiusername."&maxRows=1&q=".urlencode($user->city)."&country=".urlencode($user->country));
-    
-            if($response != "" && $xml = simplexml_load_string($response)) {
+
+            $response = self::get_url_content($url, "/search?username=" . $apiusername . "&maxRows=1&q=" . urlencode($user->city) . "&country=" . urlencode($user->country));
+
+            if ($response != "" && $xml = simplexml_load_string($response)) {
                 if (isset($xml->geoname->lat)) {
                     $coordinates->lat = floatval($xml->geoname->lat);
                     $coordinates->lng = floatval($xml->geoname->lng);
                 }
             }
-    
+
             return $coordinates;
         }
         return false;
     }
 
     /**
- * Gets the content of a url request
- * @uses $CFG
- * @return String body of the returned request
- */
-static function get_url_content($domain, $path){
+     * Gets the content of a url request
+     * @uses $CFG
+     * @return String body of the returned request
+     */
+    static function get_url_content($domain, $path) {
 
-	global $CFG;
+        global $CFG;
 
-	$message = "GET $domain$path HTTP/1.0\r\n";
-	$msgaddress = str_replace("http://","",$domain);
-	$message .= "Host: $msgaddress\r\n";
-    $message .= "Connection: Close\r\n";
-    $message .= "\r\n";
+        $message = "GET $domain$path HTTP/1.0\r\n";
+        $msgaddress = str_replace("http://", "", $domain);
+        $message .= "Host: $msgaddress\r\n";
+        $message .= "Connection: Close\r\n";
+        $message .= "\r\n";
 
-	if($CFG->proxyhost != "" && $CFG->proxyport != 0){
-    	$address = $CFG->proxyhost;
-    	$port = $CFG->proxyport;
-	} else {
-		$address = str_replace("http://","",$domain);
-    	$port = 80;
-	}
+        if ($CFG->proxyhost != "" && $CFG->proxyport != 0) {
+            $address = $CFG->proxyhost;
+            $port = $CFG->proxyport;
+        } else {
+            $address = str_replace("http://", "", $domain);
+            $port = 80;
+        }
 
-    /* Attempt to connect to the proxy server to retrieve the remote page */
-    if(!$socket = fsockopen($address, $port, $errno, $errstring, 20)){
-        echo "Couldn't connect to host $address: $errno: $errstring\n";
-        return "";
-    }
+        /* Attempt to connect to the proxy server to retrieve the remote page */
+        if (!$socket = fsockopen($address, $port, $errno, $errstring, 20)) {
+            echo "Couldn't connect to host $address: $errno: $errstring\n";
+            return "";
+        }
 
-    fwrite($socket, $message);
-    $content = "";
-    while (!feof($socket)){
+        fwrite($socket, $message);
+        $content = "";
+        while (!feof($socket)) {
             $content .= fgets($socket, 1024);
-    }
+        }
 
-    fclose($socket);
-    $retStr = extract_body($content);
-    return $retStr;
-}
+        fclose($socket);
+        $retStr = extract_body($content);
+        return $retStr;
+    }
 
     public static function set_new_badge($awardedtoid, $badgeissuedid) {
-        set_user_preference('format_mooin4_new_badge_'.$badgeissuedid, true, $awardedtoid);
+        set_user_preference('format_mooin4_new_badge_' . $badgeissuedid, true, $awardedtoid);
     }
-    
+
     public static function unset_new_badge($viewedbyuserid, $badgehash) {
         global $DB;
         $sql = "select * from {badge_issued} where " . $DB->sql_compare_text('uniquehash') . " = :badgehash";
@@ -1720,10 +1740,9 @@ static function get_url_content($domain, $path){
         if ($records = $DB->get_records_sql($sql, $params)) {
             if (count($records) == 1) {
                 if ($records[array_key_first($records)]->userid == $viewedbyuserid) {
-                    unset_user_preference('format_mooin4_new_badge_'.$records[array_key_first($records)]->id, $viewedbyuserid);
+                    unset_user_preference('format_mooin4_new_badge_' . $records[array_key_first($records)]->id, $viewedbyuserid);
                 }
             }
         }
     }
-
 }

--- a/classes/output/courseformat/content/section.php
+++ b/classes/output/courseformat/content/section.php
@@ -88,7 +88,15 @@ class section extends section_base {
         //     set_user_preference('format_mooin4_last_section_in_course_' . $course->id, $sectionnumber, $USER->id);
         // }
 
-
+        //update course table prefix according course settings 
+        require_once(__DIR__ . '/../../../../lib.php');
+        $courseid = $course->id;
+        if (get_toggle_section_number_visibility($courseid) === 1) {
+            $data->sec_numb_visibility = true; 
+        }
+        else {
+            $data->sec_numb_visibility = false; 
+        }
 
         if (!$this->format->get_section_number()) {
             $addsectionclass = $format->get_output_classname('content\\addsection');

--- a/classes/output/courseformat/content/section/header.php
+++ b/classes/output/courseformat/content/section/header.php
@@ -66,6 +66,15 @@ class header extends header_base {
 
         $data->title = $output->section_title_without_link($section, $course);
 
+        require_once(__DIR__ . '/../../../../../lib.php');
+        $courseid = $course->id;
+        if (get_toggle_section_number_visibility($courseid) === 1) {
+            $data->sec_numb_visibility = true; 
+        }
+        else {
+            $data->sec_numb_visibility = false; 
+        }
+        
         $coursedisplay = $format->get_course_display();
         $data->headerdisplaymultipage = false;
         if ($coursedisplay == COURSE_DISPLAY_MULTIPAGE) {

--- a/classes/output/courseformat/state/section.php
+++ b/classes/output/courseformat/state/section.php
@@ -82,7 +82,18 @@ class section extends section_base {
                 $data->innerChapterNumber = $this->section->section - $parentchapterAsSection->section;
                 $data->parentChapterId = $parentchapterAsSection->id;
             }   
-            $data->prefix = utils::get_section_prefix($this->section);
+            require_once(__DIR__ . '/../../../../lib.php');
+            $courseid = $course->id;
+
+            //show course index chapter prefix numbers according settings
+            if (get_toggle_section_number_visibility($courseid) === 1) {
+                $data->sec_numb_visibility = true; 
+                $data->prefix = utils::get_section_prefix($this->section);
+            }
+            else {
+                $data->sec_numb_visibility = false; 
+                $data->prefix = '';
+            }
         }
 
         $section_progress = utils::get_section_progress($course->id, $this->section->id, $USER->id);

--- a/classes/output/courseformat/state/section.php
+++ b/classes/output/courseformat/state/section.php
@@ -81,19 +81,26 @@ class section extends section_base {
             if ($parentchapterAsSection = $DB->get_record('course_sections', array('id' => $parentchapter->sectionid))) {
                 $data->innerChapterNumber = $this->section->section - $parentchapterAsSection->section;
                 $data->parentChapterId = $parentchapterAsSection->id;
-            }   
+            }
+            
+            //show course index section prefix numbers according settings
             require_once(__DIR__ . '/../../../../lib.php');
             $courseid = $course->id;
-
-            //show course index section prefix numbers according settings
             if (get_toggle_section_number_visibility($courseid) === 1) {
-                $data->sec_numb_visibility = true; 
+                $data->sec_numb_visibility = true;
                 $data->prefix = utils::get_section_prefix($this->section);
-            }
-            else {
-                $data->sec_numb_visibility = false; 
+            } else {
+                $data->sec_numb_visibility = false;
                 $data->prefix = '';
             }
+        }
+        //set sec_numb_visibility for course index
+        require_once(__DIR__ . '/../../../../lib.php');
+        $courseid = $course->id;
+        if (get_toggle_section_number_visibility($courseid) === 1) {
+            $data->sec_numb_visibility = true;
+        } else {
+            $data->sec_numb_visibility = false;
         }
 
         $section_progress = utils::get_section_progress($course->id, $this->section->id, $USER->id);
@@ -118,7 +125,7 @@ class section extends section_base {
             }
             if (utils::is_last_section_of_chapter($this->section->id)) {
                 $data->isLastSectionOfChapter = true;
-                if (!get_user_preferences('format_mooin4_hide_modal_for_section_'.$this->section->id)) {
+                if (!get_user_preferences('format_mooin4_hide_modal_for_section_' . $this->section->id)) {
                     $data->showLastSectionModal = true;
                     //set_user_preference('format_mooin4_hide_modal_for_section_'.$this->section->id, 'true');
                 }
@@ -136,13 +143,8 @@ class section extends section_base {
             if ($last_section == $this->section->section) {
                 $data->isActiveSection = true;
             }
-            
         }
 
         return $data;
     }
-
-
-
-    
 }

--- a/classes/output/courseformat/state/section.php
+++ b/classes/output/courseformat/state/section.php
@@ -85,7 +85,7 @@ class section extends section_base {
             require_once(__DIR__ . '/../../../../lib.php');
             $courseid = $course->id;
 
-            //show course index chapter prefix numbers according settings
+            //show course index section prefix numbers according settings
             if (get_toggle_section_number_visibility($courseid) === 1) {
                 $data->sec_numb_visibility = true; 
                 $data->prefix = utils::get_section_prefix($this->section);

--- a/lang/de/format_mooin4.php
+++ b/lang/de/format_mooin4.php
@@ -182,3 +182,6 @@ $string['old_news'] = 'Ältere News';
 $string['all_news'] = 'Newsforum';
 $string['latest_post'] = 'Neuester Beitrag ';
 $string['discussion_news'] = 'Zur Nachricht';
+
+$string['toggle_section_number_visibility'] = 'Lektions- und Kapitelnummerierung aktivieren';
+$string['toggle_section_number_visibility_help'] = 'Wenn Option aktiviert ist, werden vor den selbst vergebenen Kapitel- und Lektionsnamen "Kapitel x.x" oder "Lektion x.x" angezeigt';

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -183,3 +183,6 @@ $string['old_news'] = 'Old news';
 $string['all_news'] = 'news forum';
 $string['latest_post'] = 'Latest post';
 $string['discussion_news'] = 'View post';
+
+$string['toggle_section_number_visibility'] = 'Activate section numbers';
+$string['toggle_section_number_visibility_help'] = 'If the option is enabled, "Chapter x.x" or "Lesson x.x" will be displayed before the custom chapter and lesson names.';

--- a/lib.php
+++ b/lib.php
@@ -37,22 +37,26 @@ use format_mooin4\local\utils as utils;
  * @copyright  2012 Marina Glancy
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class format_mooin4 extends core_courseformat\base {
+class format_mooin4 extends core_courseformat\base
+{
 
     /**
      * Returns true if this course format uses sections.
      *
      * @return bool
      */
-    public function uses_sections() {
+    public function uses_sections()
+    {
         return true;
     }
 
-    public function uses_course_index() {
+    public function uses_course_index()
+    {
         return true;
     }
 
-    public function uses_indentation(): bool {
+    public function uses_indentation(): bool
+    {
         return false;
     }
 
@@ -64,7 +68,8 @@ class format_mooin4 extends core_courseformat\base {
      * @param int|stdClass $section Section object from database or just field section.section
      * @return string Display name that the course format prefers, e.g. "Topic 2"
      */
-    public function get_section_name($section) {
+    public function get_section_name($section)
+    {
         $section = $this->get_section($section);
         if ((string)$section->name !== '') {
             return format_string(
@@ -87,7 +92,8 @@ class format_mooin4 extends core_courseformat\base {
      * @param stdClass $section Section object from database or just field course_sections section
      * @return string The default value for the section name.
      */
-    public function get_default_section_name($section) {
+    public function get_default_section_name($section)
+    {
         if ($section->section == 0) {
             // Return the general section.
             return get_string('section0name', 'format_mooin4');
@@ -103,7 +109,8 @@ class format_mooin4 extends core_courseformat\base {
      *
      * @return string the page title
      */
-    public function page_title(): string {
+    public function page_title(): string
+    {
         return get_string('topicoutline');
     }
 
@@ -117,7 +124,8 @@ class format_mooin4 extends core_courseformat\base {
      *
      * @return int The current value (COURSE_DISPLAY_MULTIPAGE or COURSE_DISPLAY_SINGLEPAGE)
      */
-    public function get_course_display(): int {
+    public function get_course_display(): int
+    {
         return COURSE_DISPLAY_MULTIPAGE;
     }
 
@@ -131,7 +139,8 @@ class format_mooin4 extends core_courseformat\base {
      *     'sr' (int) used by multipage formats to specify to which section to return
      * @return null|moodle_url
      */
-    public function get_view_url($section, $options = []) {
+    public function get_view_url($section, $options = [])
+    {
         global $CFG;
         $course = $this->get_course();
         $url = new moodle_url('/course/view.php', ['id' => $course->id]);
@@ -176,18 +185,21 @@ class format_mooin4 extends core_courseformat\base {
      *
      * @return stdClass
      */
-    public function supports_ajax() {
+    public function supports_ajax()
+    {
         $ajaxsupport = new stdClass();
         $ajaxsupport->capable = true;
         return $ajaxsupport;
     }
 
-    public function supports_components() {
+    public function supports_components()
+    {
         return true;
     }
 
 
-    public function extend_course_navigation($navigation, navigation_node $node) {
+    public function extend_course_navigation($navigation, navigation_node $node)
+    {
         global $PAGE, $DB, $CFG, $USER;
         // If section is specified in course/view.php, make sure it is expanded in navigation.
         if ($navigation->includesectionnum === false) {
@@ -383,7 +395,7 @@ class format_mooin4 extends core_courseformat\base {
                         if ($parentchapter = utils::get_parent_chapter($section)) {
                             $chapter_node = $node->get($parentchapter->sectionid);
                         }
-                      
+
                         if ($parentchapter && $chapter_node) {
                             $section_node = $chapter_node->add(
                                 $title,
@@ -516,14 +528,15 @@ class format_mooin4 extends core_courseformat\base {
      * @return array of default blocks, must contain two keys BLOCK_POS_LEFT and BLOCK_POS_RIGHT
      *     each of values is an array of block names (for left and right side columns)
      */
-    public function get_default_blocks() {
+    public function get_default_blocks()
+    {
         return [
             BLOCK_POS_LEFT => [],
             BLOCK_POS_RIGHT => [],
         ];
     }
 
-    
+
 
     /**
      * Adds format options elements to the course/section edit form.
@@ -534,7 +547,8 @@ class format_mooin4 extends core_courseformat\base {
      * @param bool $forsection 'true' if this is a section edit form, 'false' if this is course edit form.
      * @return array array of references to the added form elements.
      */
-    public function create_edit_form_elements(&$mform, $forsection = false) {
+    public function create_edit_form_elements(&$mform, $forsection = false)
+    {
         global $COURSE;
         $elements = parent::create_edit_form_elements($mform, $forsection);
 
@@ -567,7 +581,8 @@ class format_mooin4 extends core_courseformat\base {
      *     this object contains information about the course before update
      * @return bool whether there were any changes to the options values
      */
-    public function update_course_format_options($data, $oldcourse = null) {
+    public function update_course_format_options($data, $oldcourse = null)
+    {
         global $DB;
 
         if (!$oldcourse) {
@@ -646,7 +661,8 @@ class format_mooin4 extends core_courseformat\base {
      * @param int|stdClass|section_info $section
      * @return bool
      */
-    public function can_delete_section($section) {
+    public function can_delete_section($section)
+    {
         return true;
     }
 
@@ -682,7 +698,8 @@ class format_mooin4 extends core_courseformat\base {
      *
      * @return bool
      */
-    public function supports_news() {
+    public function supports_news()
+    {
         return true;
     }
 
@@ -694,7 +711,8 @@ class format_mooin4 extends core_courseformat\base {
      * @param stdClass|section_info $section section where this module is located or will be added to
      * @return bool
      */
-    public function allow_stealth_module_visibility($cm, $section) {
+    public function allow_stealth_module_visibility($cm, $section)
+    {
         // Allow the third visibility state inside visible sections or in section 0.
         return !$section->section || $section->visible;
     }
@@ -739,7 +757,8 @@ class format_mooin4 extends core_courseformat\base {
     //     return $rv;
     // }
 
-    public function section_action($section, $action, $sr) {
+    public function section_action($section, $action, $sr)
+    {
         global $PAGE;
         if (!$this->uses_sections() || !$section->section) {
             // No section actions are allowed if course format does not support sections.
@@ -796,7 +815,8 @@ class format_mooin4 extends core_courseformat\base {
      * @return array the list of configuration settings
      * @since Moodle 3.5
      */
-    public function get_config_for_external() {
+    public function get_config_for_external()
+    {
         // Return everything (nothing to hide).
         $formatoptions = $this->get_format_options();
         $formatoptions['indentation'] = get_config('format_mooin4', 'indentation');
@@ -814,7 +834,8 @@ class format_mooin4 extends core_courseformat\base {
      * @param mixed $newvalue
      * @return \core\output\inplace_editable
      */
-    public function inplace_editable_update_section_name($section, $itemtype, $newvalue) {
+    public function inplace_editable_update_section_name($section, $itemtype, $newvalue)
+    {
         global $DB;
         if ($itemtype === 'sectionname' || $itemtype === 'sectionnamenl') {
             $context = context_course::instance($section->course);
@@ -835,7 +856,7 @@ class format_mooin4 extends core_courseformat\base {
 
 
 
-/**
+    /**
      * Returns if an specific section is visible to the current user.
      *
      * Formats can overrride this method to implement any special section logic.
@@ -843,7 +864,8 @@ class format_mooin4 extends core_courseformat\base {
      * @param section_info $section the section modinfo
      * @return bool;
      */
-    public function is_section_visible(section_info $section): bool {
+    public function is_section_visible(section_info $section): bool
+    {
         // Previous to Moodle 4.0 thas logic was hardcoded. To prevent errors in the contrib plugins
         // the default logic is the same required for topics and weeks format and still uses
         // a "hiddensections" format setting.
@@ -857,6 +879,44 @@ class format_mooin4 extends core_courseformat\base {
             ($section->visible && !$section->available && !empty($section->availableinfo)) ||
             (!$section->visible && !$hidesections);
     }
+
+
+    /**
+     * Returns the course format options, with the possibility to include additional options for the edit form.
+     *
+     * This method defines and retrieves the course format options, allowing formats to include custom settings
+     * and modify their behavior depending on whether they are being used for editing or display purposes.
+     *
+     * @param bool $foreditform Whether to include additional options specific to the edit form.
+     * @return array The course format options, including defaults and edit form specifics.
+     */
+    public function course_format_options($foreditform = false)
+    {
+        static $courseformatoptions = false;
+        if ($courseformatoptions === false) {
+            $courseconfig = get_config('moodlecourse');
+            $courseformatoptions = [
+                'toggle_section_number_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
+            ];
+        }
+        if ($foreditform) {
+            if (!isset($courseformatoptions['toggle_section_number_visibility']['label'])) {
+                $courseformatoptionsedit = [
+                    'toggle_section_number_visibility' => [
+                        'label' => new lang_string('toggle_section_number_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_section_number_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
+                ];
+                $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
+            }
+        }
+        return $courseformatoptions;
+    }
 }
 
 /**
@@ -867,7 +927,8 @@ class format_mooin4 extends core_courseformat\base {
  * @param mixed $newvalue
  * @return inplace_editable
  */
-function format_mooin4_inplace_editable($itemtype, $itemid, $newvalue) {
+function format_mooin4_inplace_editable($itemtype, $itemid, $newvalue)
+{
     global $DB, $CFG;
     require_once($CFG->dirroot . '/course/lib.php');
     if ($itemtype === 'sectionname' || $itemtype === 'sectionnamenl') {
@@ -880,7 +941,8 @@ function format_mooin4_inplace_editable($itemtype, $itemid, $newvalue) {
     }
 }
 
-function format_mooin4_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {
+function format_mooin4_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array())
+{
     require_login($course, true);
 
     if ($filearea != 'headerimagemobile' and $filearea != 'headerimagedesktop') {
@@ -908,3 +970,31 @@ function format_mooin4_pluginfile($course, $cm, $context, $filearea, $args, $for
     send_stored_file($file, 0, 0, $forcedownload, $options);
 }
 
+
+
+
+/**
+ * Holt die benutzerdefinierte Einstellung 'toggle_section_number_visibility' eines Kurses.
+ *
+ * @param int $courseid Die ID des Kurses.
+ * @return int Der Wert der Einstellung (1 für sichtbar, 0 für unsichtbar).
+ */
+function get_toggle_section_number_visibility($courseid)
+{
+    // Kursdaten abrufen
+    $course = get_course($courseid);
+
+    // Kursformat abrufen
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_section_number_visibility'])) {
+        // Wenn der Wert gesetzt ist, diesen verwenden
+        return $formatoptions['toggle_section_number_visibility'];
+    } else {
+        // Andernfalls den Standardwert verwenden
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_section_number_visibility']['default'];
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -324,8 +324,12 @@ class format_mooin4 extends core_courseformat\base {
                     $lastvisitedsection = '';
 
                     if ($chapter = $DB->get_record('format_mooin4_chapter', array('sectionid' => $section->id))) {
-
-                        $pre = get_string('chapter', 'format_mooin4') . ' ' . $chapter->chapter . ': ';
+                        //show breadcrump chapter prefix according settings
+                        if (get_toggle_section_number_visibility($courseid)  === 1) {
+                            $pre = get_string('chapter', 'format_mooin4') . ' ' . $chapter->chapter . ': ';
+                        } else {
+                            $pre = '';
+                        }
                         $title = $pre . get_section_name($this->get_course(), $section);
                         if (count(utils::get_sectionids_for_chapter($chapter->id)) > 0) {
                             $url = new moodle_url('/course/view.php', array('id' => $courseid, 'section' => $section->section + 1));
@@ -361,7 +365,12 @@ class format_mooin4 extends core_courseformat\base {
                         $chapter_node->add_class('chapter' . $completed . $lastvisitedsection);
                         // $chapter_node->add_class('collapsed');
                     } else {
-                        $pre = get_string('lesson', 'format_mooin4') . ' ' . utils::get_section_prefix($section) . ': ';
+                        //show breadcrump lesson prefix according settings
+                        if (get_toggle_section_number_visibility($courseid)  === 1) {
+                            $pre = get_string('lesson', 'format_mooin4') . ' ' . utils::get_section_prefix($section) . ': ';
+                        } else {
+                            $pre = '';
+                        }
                         if ($section->name) {
                             $title = $pre . get_section_name($this->get_course(), $section);
                         } else {

--- a/lib.php
+++ b/lib.php
@@ -37,26 +37,22 @@ use format_mooin4\local\utils as utils;
  * @copyright  2012 Marina Glancy
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class format_mooin4 extends core_courseformat\base
-{
+class format_mooin4 extends core_courseformat\base {
 
     /**
      * Returns true if this course format uses sections.
      *
      * @return bool
      */
-    public function uses_sections()
-    {
+    public function uses_sections() {
         return true;
     }
 
-    public function uses_course_index()
-    {
+    public function uses_course_index() {
         return true;
     }
 
-    public function uses_indentation(): bool
-    {
+    public function uses_indentation(): bool {
         return false;
     }
 
@@ -68,8 +64,7 @@ class format_mooin4 extends core_courseformat\base
      * @param int|stdClass $section Section object from database or just field section.section
      * @return string Display name that the course format prefers, e.g. "Topic 2"
      */
-    public function get_section_name($section)
-    {
+    public function get_section_name($section) {
         $section = $this->get_section($section);
         if ((string)$section->name !== '') {
             return format_string(
@@ -92,8 +87,7 @@ class format_mooin4 extends core_courseformat\base
      * @param stdClass $section Section object from database or just field course_sections section
      * @return string The default value for the section name.
      */
-    public function get_default_section_name($section)
-    {
+    public function get_default_section_name($section) {
         if ($section->section == 0) {
             // Return the general section.
             return get_string('section0name', 'format_mooin4');
@@ -109,8 +103,7 @@ class format_mooin4 extends core_courseformat\base
      *
      * @return string the page title
      */
-    public function page_title(): string
-    {
+    public function page_title(): string {
         return get_string('topicoutline');
     }
 
@@ -124,8 +117,7 @@ class format_mooin4 extends core_courseformat\base
      *
      * @return int The current value (COURSE_DISPLAY_MULTIPAGE or COURSE_DISPLAY_SINGLEPAGE)
      */
-    public function get_course_display(): int
-    {
+    public function get_course_display(): int {
         return COURSE_DISPLAY_MULTIPAGE;
     }
 
@@ -139,8 +131,7 @@ class format_mooin4 extends core_courseformat\base
      *     'sr' (int) used by multipage formats to specify to which section to return
      * @return null|moodle_url
      */
-    public function get_view_url($section, $options = [])
-    {
+    public function get_view_url($section, $options = []) {
         global $CFG;
         $course = $this->get_course();
         $url = new moodle_url('/course/view.php', ['id' => $course->id]);
@@ -185,21 +176,18 @@ class format_mooin4 extends core_courseformat\base
      *
      * @return stdClass
      */
-    public function supports_ajax()
-    {
+    public function supports_ajax() {
         $ajaxsupport = new stdClass();
         $ajaxsupport->capable = true;
         return $ajaxsupport;
     }
 
-    public function supports_components()
-    {
+    public function supports_components() {
         return true;
     }
 
 
-    public function extend_course_navigation($navigation, navigation_node $node)
-    {
+    public function extend_course_navigation($navigation, navigation_node $node) {
         global $PAGE, $DB, $CFG, $USER;
         // If section is specified in course/view.php, make sure it is expanded in navigation.
         if ($navigation->includesectionnum === false) {
@@ -528,8 +516,7 @@ class format_mooin4 extends core_courseformat\base
      * @return array of default blocks, must contain two keys BLOCK_POS_LEFT and BLOCK_POS_RIGHT
      *     each of values is an array of block names (for left and right side columns)
      */
-    public function get_default_blocks()
-    {
+    public function get_default_blocks() {
         return [
             BLOCK_POS_LEFT => [],
             BLOCK_POS_RIGHT => [],
@@ -547,8 +534,7 @@ class format_mooin4 extends core_courseformat\base
      * @param bool $forsection 'true' if this is a section edit form, 'false' if this is course edit form.
      * @return array array of references to the added form elements.
      */
-    public function create_edit_form_elements(&$mform, $forsection = false)
-    {
+    public function create_edit_form_elements(&$mform, $forsection = false) {
         global $COURSE;
         $elements = parent::create_edit_form_elements($mform, $forsection);
 
@@ -581,8 +567,7 @@ class format_mooin4 extends core_courseformat\base
      *     this object contains information about the course before update
      * @return bool whether there were any changes to the options values
      */
-    public function update_course_format_options($data, $oldcourse = null)
-    {
+    public function update_course_format_options($data, $oldcourse = null) {
         global $DB;
 
         if (!$oldcourse) {
@@ -661,8 +646,7 @@ class format_mooin4 extends core_courseformat\base
      * @param int|stdClass|section_info $section
      * @return bool
      */
-    public function can_delete_section($section)
-    {
+    public function can_delete_section($section) {
         return true;
     }
 
@@ -698,8 +682,7 @@ class format_mooin4 extends core_courseformat\base
      *
      * @return bool
      */
-    public function supports_news()
-    {
+    public function supports_news() {
         return true;
     }
 
@@ -711,8 +694,7 @@ class format_mooin4 extends core_courseformat\base
      * @param stdClass|section_info $section section where this module is located or will be added to
      * @return bool
      */
-    public function allow_stealth_module_visibility($cm, $section)
-    {
+    public function allow_stealth_module_visibility($cm, $section) {
         // Allow the third visibility state inside visible sections or in section 0.
         return !$section->section || $section->visible;
     }
@@ -757,8 +739,7 @@ class format_mooin4 extends core_courseformat\base
     //     return $rv;
     // }
 
-    public function section_action($section, $action, $sr)
-    {
+    public function section_action($section, $action, $sr) {
         global $PAGE;
         if (!$this->uses_sections() || !$section->section) {
             // No section actions are allowed if course format does not support sections.
@@ -815,8 +796,7 @@ class format_mooin4 extends core_courseformat\base
      * @return array the list of configuration settings
      * @since Moodle 3.5
      */
-    public function get_config_for_external()
-    {
+    public function get_config_for_external() {
         // Return everything (nothing to hide).
         $formatoptions = $this->get_format_options();
         $formatoptions['indentation'] = get_config('format_mooin4', 'indentation');
@@ -834,8 +814,7 @@ class format_mooin4 extends core_courseformat\base
      * @param mixed $newvalue
      * @return \core\output\inplace_editable
      */
-    public function inplace_editable_update_section_name($section, $itemtype, $newvalue)
-    {
+    public function inplace_editable_update_section_name($section, $itemtype, $newvalue) {
         global $DB;
         if ($itemtype === 'sectionname' || $itemtype === 'sectionnamenl') {
             $context = context_course::instance($section->course);
@@ -864,8 +843,7 @@ class format_mooin4 extends core_courseformat\base
      * @param section_info $section the section modinfo
      * @return bool;
      */
-    public function is_section_visible(section_info $section): bool
-    {
+    public function is_section_visible(section_info $section): bool {
         // Previous to Moodle 4.0 thas logic was hardcoded. To prevent errors in the contrib plugins
         // the default logic is the same required for topics and weeks format and still uses
         // a "hiddensections" format setting.
@@ -890,8 +868,7 @@ class format_mooin4 extends core_courseformat\base
      * @param bool $foreditform Whether to include additional options specific to the edit form.
      * @return array The course format options, including defaults and edit form specifics.
      */
-    public function course_format_options($foreditform = false)
-    {
+    public function course_format_options($foreditform = false) {
         static $courseformatoptions = false;
         if ($courseformatoptions === false) {
             $courseconfig = get_config('moodlecourse');
@@ -927,8 +904,7 @@ class format_mooin4 extends core_courseformat\base
  * @param mixed $newvalue
  * @return inplace_editable
  */
-function format_mooin4_inplace_editable($itemtype, $itemid, $newvalue)
-{
+function format_mooin4_inplace_editable($itemtype, $itemid, $newvalue) {
     global $DB, $CFG;
     require_once($CFG->dirroot . '/course/lib.php');
     if ($itemtype === 'sectionname' || $itemtype === 'sectionnamenl') {
@@ -941,8 +917,7 @@ function format_mooin4_inplace_editable($itemtype, $itemid, $newvalue)
     }
 }
 
-function format_mooin4_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array())
-{
+function format_mooin4_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {
     require_login($course, true);
 
     if ($filearea != 'headerimagemobile' and $filearea != 'headerimagedesktop') {
@@ -979,8 +954,7 @@ function format_mooin4_pluginfile($course, $cm, $context, $filearea, $args, $for
  * @param int $courseid Die ID des Kurses.
  * @return int Der Wert der Einstellung (1 für sichtbar, 0 für unsichtbar).
  */
-function get_toggle_section_number_visibility($courseid)
-{
+function get_toggle_section_number_visibility($courseid) {
     // Kursdaten abrufen
     $course = get_course($courseid);
 

--- a/templates/local/content/section/header.mustache
+++ b/templates/local/content/section/header.mustache
@@ -50,7 +50,12 @@
     <h3 id="sectionid-{{id}}-title" class="sectionname">
         {{^editing}}
         {{#chapter}}
-            <a data-toggle="collapse" href="#chapter-{{{chapter_num}}}" class="{{^containsActiveSection}} collapsed {{/containsActiveSection}}" role="button" aria-expanded="false" aria-controls="chapter-{{{chapter_num}}}"><i class="bi bi-caret-right-fill"></i> <span>{{#str}}chapter, format_mooin4{{/str}} {{{prefix}}}: {{{title}}} </span></a>
+            {{#sec_numb_visibility}}
+                <a data-toggle="collapse" href="#chapter-{{{chapter_num}}}" class="{{^containsActiveSection}} collapsed {{/containsActiveSection}}" role="button" aria-expanded="false" aria-controls="chapter-{{{chapter_num}}}"><i class="bi bi-caret-right-fill"></i> <span>{{#str}}chapter, format_mooin4{{/str}} {{{prefix}}}: {{{title}}} </span></a>
+            {{/sec_numb_visibility}}
+            {{^sec_numb_visibility}}
+                <a data-toggle="collapse" href="#chapter-{{{chapter_num}}}" class="{{^containsActiveSection}} collapsed {{/containsActiveSection}}" role="button" aria-expanded="false" aria-controls="chapter-{{{chapter_num}}}"><i class="bi bi-caret-right-fill"></i> <span>{{{title}}} </span></a>
+            {{/sec_numb_visibility}}
         {{/chapter}}
         {{^chapter}}
             <a href="{{{url}}}">{{^singleheader}}{{#str}}lesson, format_mooin4{{/str}} {{{prefix}}}: {{/singleheader}}{{{title_without_link}}}</a>

--- a/templates/local/content/section/header.mustache
+++ b/templates/local/content/section/header.mustache
@@ -58,7 +58,12 @@
             {{/sec_numb_visibility}}
         {{/chapter}}
         {{^chapter}}
-            <a href="{{{url}}}">{{^singleheader}}{{#str}}lesson, format_mooin4{{/str}} {{{prefix}}}: {{/singleheader}}{{{title_without_link}}}</a>
+            {{#sec_numb_visibility}}
+                <a href="{{{url}}}">{{^singleheader}}{{#str}}lesson, format_mooin4{{/str}} {{{prefix}}}: {{/singleheader}}{{{title_without_link}}}</a>
+            {{/sec_numb_visibility}}
+            {{^sec_numb_visibility}}
+                <a href="{{{url}}}">{{{title_without_link}}}</a>
+            {{/sec_numb_visibility}}
         {{/chapter}}
         {{/editing}}
     </h3>

--- a/templates/local/courseindex/section.mustache
+++ b/templates/local/courseindex/section.mustache
@@ -89,7 +89,11 @@
         >
         <i class="bi bi-caret-right-fill" data-for="caret"></i>
         <span>
-        {{#str}}chapter, format_mooin4{{/str}} <span data-for="index_number" data-id="{{id}}">{{{isChapter}}}</span>:
+            {{#sec_numb_visibility}}
+                {{#str}}chapter, format_mooin4{{/str}} <span data-for="index_number" data-id="{{id}}">{{{isChapter}}}</span>:
+            {{/sec_numb_visibility}}
+            {{^sec_numb_visibility}}
+            {{/sec_numb_visibility}}
             {{{title}}}
         </span>
         </span>
@@ -129,8 +133,13 @@
             data-for="section_title"
             tabindex="-1"
         >
-       
+               
+        {{#sec_numb_visibility}}
           <span data-for="index_number" data-id="{{id}}">{{{prefix}}}</span>: 
+        {{/sec_numb_visibility}}
+        {{^sec_numb_visibility}}
+           
+        {{/sec_numb_visibility}}
             {{{title}}}
             
         </a>

--- a/templates/local/courseindex/section.mustache
+++ b/templates/local/courseindex/section.mustache
@@ -92,8 +92,6 @@
             {{#sec_numb_visibility}}
                 {{#str}}chapter, format_mooin4{{/str}} <span data-for="index_number" data-id="{{id}}">{{{isChapter}}}</span>:
             {{/sec_numb_visibility}}
-            {{^sec_numb_visibility}}
-            {{/sec_numb_visibility}}
             {{{title}}}
         </span>
         </span>
@@ -134,12 +132,9 @@
             tabindex="-1"
         >
                
-        {{#sec_numb_visibility}}
-          <span data-for="index_number" data-id="{{id}}">{{{prefix}}}</span>: 
-        {{/sec_numb_visibility}}
-        {{^sec_numb_visibility}}
-           
-        {{/sec_numb_visibility}}
+            {{#sec_numb_visibility}}
+            <span data-for="index_number" data-id="{{id}}">{{{prefix}}}</span>: 
+            {{/sec_numb_visibility}}
             {{{title}}}
             
         </a>


### PR DESCRIPTION
In course settings, a new option is added so the default prefixes "chapter 1:" and "lesson 1.1" visibility can be toggled