### PR TITLE
dirty fix for bug in mooin_chapter table deleted sections included

### DIFF
--- a/classes/local/utils.php
+++ b/classes/local/utils.php
@@ -732,7 +732,7 @@ class utils {
         }
     
         $chapters = $DB->get_records('format_mooin4_chapter', array('courseid' => $section->course));
-        foreach ($chapters as $chapter) {
+        foreach ($chapters as $chapter) {            
             if (isset($CHAPTERS[$chapter->id]) && isset($CHAPTERS[$chapter->id]->sectionids)) {
                 $sids = $CHAPTERS[$chapter->id]->sectionids;
             }
@@ -755,8 +755,17 @@ class utils {
         global $DB;      
         $sectionids = array();
         if ($chapter = $DB->get_record('format_mooin4_chapter', array('id' => $chapterid))) {
+
             if ($chaptersection = $DB->get_record('course_sections', array('id' => $chapter->sectionid))) {
-                if ($nextchapter = $DB->get_record('format_mooin4_chapter', array('courseid' => $chapter->courseid, 'chapter' => $chapter->chapter + 1))) {
+                if ($nextchapters = $DB->get_records('format_mooin4_chapter', array('courseid' => $chapter->courseid, 'chapter' => $chapter->chapter + 1))) {
+                    // there is a bug somewhere - the mooin4_chapter table is not updated correctly
+                    // it contains chapters with sectionids that are not in the course or elsewhere
+                    foreach ($nextchapters as $nextchapter) {
+                        if ($DB->get_record('course_sections', array('id' => $nextchapter->sectionid))) {
+                            break;
+                        }
+                    }
+
                     if ($nextchaptersection = $DB->get_record('course_sections', array('id' => $nextchapter->sectionid))) {
                         $sql = 'SELECT cs.id 
                                 FROM {course_sections} cs


### PR DESCRIPTION
Wie lange das Problem exisitiert ist nicht klar. Mit der Optimierung der Ladezeiten für die Kapitelgestaltung wurde der Fehler erst offenbart, dass es verweiste sections, die Kapiteln zugeordnet sind in der mooin4_chaoter Tabelle.
Ich habe viel ausprobiert, warum überhaupt gelöschte sections in der Kapitel Tabelle auftauchen. Diesen Fehler konnte ich nicht provozieren. Besser wäre es auch wenn die Tabellen überprüft werden und korrigiert. Aber da stellt sich die Frage nach der Effizienz und vor allem warum der Fehler überhaupt auftritt oder ob das nur in einer Version passiert ist, was nun gefixt ist. 