### PR TITLE
M41-194-newsforum-preview: Fix misaligned notification-badge and text layout

### DIFF
--- a/templates/local/content/frontpage/news_section.mustache
+++ b/templates/local/content/frontpage/news_section.mustache
@@ -55,7 +55,7 @@
     </div>
     
     <div class="news-mobile d-flex d-sm-none">
-        <div class="position-relative">
+        <div class="position-relative news-icon-container">
             <i class="bi bi-newspaper mr-2"></i>
             {{^no_new_news}}
             <span class="notification-badge notification-badge--mobile position-absolute">{{{unreadNewsNumber}}}</span>

--- a/templates/local/content/frontpage/news_section.mustache
+++ b/templates/local/content/frontpage/news_section.mustache
@@ -66,9 +66,8 @@
             <div class="d-flex flex-column">
                 <a href="{{{discussion_url}}}" class="caption caption--sm">{{#str}} latest_post, format_mooin4 {{/str}}</a>
                 <span class="news-title">{{{news_title}}}</span>
-            </div>
-        
-        <a href="{{{newsforumUrl}}}" class="ml-auto">{{#str}} all_news_mobile, format_mooin4 {{/str}}</a>
+                <a href="{{{newsforumUrl}}}" class="ml-auto">{{#str}} all_news_mobile, format_mooin4 {{/str}}</a>
+            </div>        
     </div>
     
 </div>


### PR DESCRIPTION
Ticket: https://isy-thl.atlassian.net/browse/M41-194

Für die Überprüfung bitte die Änderungen aus dem Branch fix/M41-194-newsforum-preview sowohl im Theme- als auch im Format-Repo übernehmen. Da das Problem mit dem verrutschten Notification-Badge nur in Firefox aufgetreten ist, sollte die Änderung insbesondere in Firefox getestet werden.

Bitte zum Testen in der mobilen Ansicht folgende Schritte ausführen:
- [x] Im Kurs unter "Ankündigungen" ein "Neues Thema hinzufügen"
- [x] Einen langen Betreff eingeben, sodass im Preview-Fenster normalerweise 3 Zeilen entstehen würden
- [x] Auf "Erweitert" klicken, um die Option "Mitteilung ohne Verzögerung senden" zu wählen
- [x] Beitrag absenden und zur Kursübersicht navigieren

Erwartetes Ergebnis:
- Das Preview-Fenster ist auf 2 Zeilen begrenzt und der Text wird am Ende ausgepunktet
- Das Notification-Badge ist korrekt positioniert, es sollte sich in der rechten oberen Ecke des Newspaper-Icons befinden
- Der Link "Alle Beiträge" befindet sich rechtsbündig unterhalb des Preview-Texts