### PR TITLE
Mooin 405 hide frontpage elements

### DIFF
--- a/classes/local/utils.php
+++ b/classes/local/utils.php
@@ -382,7 +382,7 @@ class utils {
         global $DB, $USER;
 
         // SQL query to get all unread posts
-        $sql = 'SELECT fp.*, f.id as forumid, fd.groupid, fd.id as discussionid, cm.id as cmid
+        $sql = 'SELECT DISTINCT fp.id AS uniqueid, fp.*, f.id as forumid, fd.groupid, fd.id as discussionid, cm.id as cmid
                 FROM {forum_posts} as fp
                 JOIN {forum_discussions} as fd ON fp.discussion = fd.id
                 JOIN {forum} as f ON fd.forum = f.id
@@ -409,7 +409,7 @@ class utils {
             'wait' => time() - 1800
         );
 
-        $unreadposts = $DB->get_records_sql($sql, $params);
+        $unreadposts = $DB->get_recordset_sql($sql, $params);
         $visible_unread_posts = 0;
 
         // Check visibility of each post

--- a/classes/output/courseformat/content/coursefrontpage.php
+++ b/classes/output/courseformat/content/coursefrontpage.php
@@ -110,13 +110,29 @@ class coursefrontpage implements renderable {
             $data->discussion_visibility = false; 
         }
 
+        if (get_toggle_userlist_visibility($courseid) === 1) {
+            $data->userlist_visibility = true; 
+        }
+        else {
+            $data->userlist_visibility = false; 
+        }
+
+        if (
+            get_toggle_discussion_visibility($courseid) === 0
+            && get_toggle_userlist_visibility($courseid) === 0
+        ) {
+            $data->community_visibility = false;
+        } else {
+            $data->community_visibility = true;
+        }
+
         if (get_toggle_badge_visibility($courseid) === 1) {
             $data->badge_visibility = true; 
         }
         else {
             $data->badge_visibility = false; 
         }
-
+  
         if (get_toggle_certificate_visibility($courseid) === 1) {
             $data->certificate_visibility = true; 
         }
@@ -139,6 +155,16 @@ class coursefrontpage implements renderable {
         ) {
             $data->badge_cert_hide = true;
         }
+
+        if (
+            get_toggle_badge_visibility($courseid) === 0
+            && get_toggle_certificate_visibility($courseid) === 0
+            && get_toggle_discussion_visibility($courseid) === 0
+            && get_toggle_userlist_visibility($courseid) === 0
+        ) {
+            $data->hide_coursefrontpage_side = true;
+        }
+        
 
 
         $coursecontext = context_course::instance($course->id);

--- a/classes/output/courseformat/content/coursefrontpage.php
+++ b/classes/output/courseformat/content/coursefrontpage.php
@@ -85,6 +85,19 @@ class coursefrontpage implements renderable {
             'unenrolurl' => utils::get_unenrol_url($course->id),
         ];
 
+        require_once(__DIR__ . '/../../../../lib.php');
+        $courseid = $course->id;
+
+        //handle data for course element visibility
+        if (get_toggle_newssection_visibility($courseid) === 1) {
+            $data->newssection_visibility = true; 
+        }
+        else {
+           $data->newssection_visibility = false; 
+        }
+
+
+
         $coursecontext = context_course::instance($course->id);
         if (has_capability('moodle/course:update', $coursecontext)) {
             $data->has_capability = true;

--- a/classes/output/courseformat/content/coursefrontpage.php
+++ b/classes/output/courseformat/content/coursefrontpage.php
@@ -103,6 +103,13 @@ class coursefrontpage implements renderable {
             $data->progressbar_visibility = false; 
         }
 
+        if (get_toggle_discussion_visibility($courseid) === 1) {
+            $data->discussion_visibility = true; 
+        }
+        else {
+            $data->discussion_visibility = false; 
+        }
+
 
 
         $coursecontext = context_course::instance($course->id);

--- a/classes/output/courseformat/content/coursefrontpage.php
+++ b/classes/output/courseformat/content/coursefrontpage.php
@@ -110,6 +110,12 @@ class coursefrontpage implements renderable {
             $data->discussion_visibility = false; 
         }
 
+        if (get_toggle_badge_visibility($courseid) === 1) {
+            $data->badge_visibility = true; 
+        }
+        else {
+            $data->badge_visibility = false; 
+        }
 
 
         $coursecontext = context_course::instance($course->id);

--- a/classes/output/courseformat/content/coursefrontpage.php
+++ b/classes/output/courseformat/content/coursefrontpage.php
@@ -71,7 +71,7 @@ class coursefrontpage implements renderable {
         $participants = $this->participants;
         $course = $format->get_course();
 
-        
+
 
         $data = (object)[
             'header' => $header->export_for_template($output),
@@ -89,60 +89,72 @@ class coursefrontpage implements renderable {
         $courseid = $course->id;
 
         //handle data for course element visibility
-        if (get_toggle_newssection_visibility($courseid) === 1) {
-            $data->newssection_visibility = true; 
-        }
-        else {
-           $data->newssection_visibility = false; 
-        }
-
-        if (get_toggle_progressbar_visibility($courseid) === 1) {
-            $data->progressbar_visibility = true; 
-        }
-        else {
-            $data->progressbar_visibility = false; 
+        if (get_toggle_newssection_visibility($courseid) == 1) {
+            $data->newssection_visibility = true;
+        } else {
+            $data->newssection_visibility = false;
         }
 
-        if (get_toggle_discussion_visibility($courseid) === 1) {
-            $data->discussion_visibility = true; 
-        }
-        else {
-            $data->discussion_visibility = false; 
-        }
-
-        if (get_toggle_userlist_visibility($courseid) === 1) {
-            $data->userlist_visibility = true; 
-        }
-        else {
-            $data->userlist_visibility = false; 
+        if (get_toggle_progressbar_visibility($courseid) == 1) {
+            $data->progressbar_visibility = true;
+        } else {
+            $data->progressbar_visibility = false;
         }
 
         if (
-            get_toggle_discussion_visibility($courseid) === 0
-            && get_toggle_userlist_visibility($courseid) === 0
+            get_toggle_discussion_visibility($courseid) == 1
+            && get_config('format_mooin4', "toggle_global_discussion_visibility") == 1
+        ) {
+            $data->discussion_visibility = true;
+        } else {
+            $data->discussion_visibility = false;
+        }
+
+        if (
+            get_toggle_userlist_visibility($courseid) == 1
+            && get_config('format_mooin4', "toggle_global_userlist_visibility") == 1
+        ) {
+            $data->userlist_visibility = true;
+        } else {
+            $data->userlist_visibility = false;
+        }
+
+        if (
+            (get_toggle_discussion_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_discussion_visibility") == 0)
+            && (get_toggle_userlist_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_userlist_visibility") == 0)
         ) {
             $data->community_visibility = false;
         } else {
             $data->community_visibility = true;
         }
 
-        if (get_toggle_badge_visibility($courseid) === 1) {
-            $data->badge_visibility = true; 
-        }
-        else {
-            $data->badge_visibility = false; 
-        }
-  
-        if (get_toggle_certificate_visibility($courseid) === 1) {
-            $data->certificate_visibility = true; 
-        }
-        else {
-            $data->certificate_visibility = false; 
-        }
-        
         if (
-            get_toggle_badge_visibility($courseid) === 1
-            && get_toggle_certificate_visibility($courseid) === 1
+            get_toggle_badge_visibility($courseid) == 1
+            && get_config('format_mooin4', "toggle_global_badge_visibility") == 1
+        ) {
+            $data->badge_visibility = true;
+        } else {
+            $data->badge_visibility = false;
+        }
+
+        if (
+            get_toggle_certificate_visibility($courseid) == 1
+            && get_config('format_mooin4', "toggle_global_certificate_visibility") == 1
+        ) {
+            $data->certificate_visibility = true;
+        } else {
+            $data->certificate_visibility = false;
+        }
+
+        if (
+            (get_toggle_badge_visibility($courseid) == 1
+                && get_config('format_mooin4', "toggle_global_badge_visibility") == 1)
+            && (get_toggle_certificate_visibility($courseid) == 1
+                && get_config('format_mooin4', "toggle_global_certificate_visibility") == 1)
+            && (get_toggle_discussion_visibility($courseid) == 1
+                && get_config('format_mooin4', "toggle_global_discussion_visibility") == 1)
         ) {
             $data->badge_cert_visibility = true;
         } else {
@@ -150,22 +162,26 @@ class coursefrontpage implements renderable {
         }
 
         if (
-            get_toggle_badge_visibility($courseid) === 0
-            && get_toggle_certificate_visibility($courseid) === 0
+            (get_toggle_badge_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_badge_visibility") == 0)
+            && (get_toggle_certificate_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_certificate_visibility") == 0)
         ) {
             $data->badge_cert_hide = true;
         }
 
         if (
-            get_toggle_badge_visibility($courseid) === 0
-            && get_toggle_certificate_visibility($courseid) === 0
-            && get_toggle_discussion_visibility($courseid) === 0
-            && get_toggle_userlist_visibility($courseid) === 0
+            (get_toggle_badge_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_badge_visibility") == 0)
+            && (get_toggle_certificate_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_certificate_visibility") == 0)
+            && (get_toggle_discussion_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_discussion_visibility") == 0)
+            && (get_toggle_userlist_visibility($courseid) == 0
+                || get_config('format_mooin4', "toggle_global_userlist_visibility") == 0)
         ) {
             $data->hide_coursefrontpage_side = true;
         }
-        
-
 
         $coursecontext = context_course::instance($course->id);
         if (has_capability('moodle/course:update', $coursecontext)) {

--- a/classes/output/courseformat/content/coursefrontpage.php
+++ b/classes/output/courseformat/content/coursefrontpage.php
@@ -117,6 +117,29 @@ class coursefrontpage implements renderable {
             $data->badge_visibility = false; 
         }
 
+        if (get_toggle_certificate_visibility($courseid) === 1) {
+            $data->certificate_visibility = true; 
+        }
+        else {
+            $data->certificate_visibility = false; 
+        }
+        
+        if (
+            get_toggle_badge_visibility($courseid) === 1
+            && get_toggle_certificate_visibility($courseid) === 1
+        ) {
+            $data->badge_cert_visibility = true;
+        } else {
+            $data->badge_cert_visibility = false;
+        }
+
+        if (
+            get_toggle_badge_visibility($courseid) === 0
+            && get_toggle_certificate_visibility($courseid) === 0
+        ) {
+            $data->badge_cert_hide = true;
+        }
+
 
         $coursecontext = context_course::instance($course->id);
         if (has_capability('moodle/course:update', $coursecontext)) {

--- a/classes/output/courseformat/content/coursefrontpage.php
+++ b/classes/output/courseformat/content/coursefrontpage.php
@@ -96,6 +96,13 @@ class coursefrontpage implements renderable {
            $data->newssection_visibility = false; 
         }
 
+        if (get_toggle_progressbar_visibility($courseid) === 1) {
+            $data->progressbar_visibility = true; 
+        }
+        else {
+            $data->progressbar_visibility = false; 
+        }
+
 
 
         $coursecontext = context_course::instance($course->id);

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -114,21 +114,33 @@ class renderer extends section_renderer {
             //check course settings 
             require_once(__DIR__ . '/../../../../lib.php');
             $courseid = $course->id;
-            if (get_config('format_mooin4', "badges") && get_toggle_badge_visibility($courseid) === 1) {
+            if (
+                get_config('format_mooin4', "badges")
+                && get_toggle_badge_visibility($courseid) === 1
+                && get_config('format_mooin4', "toggle_global_badge_visibility")
+            ) {
                 $data['badges'] = [
                     'url' => $badgesUrl,
                     'active' => $this->check_if_active($badgesUrl),
                 ];
             }
 
-            if (get_config('format_mooin4', "certificates") && get_toggle_certificate_visibility($courseid) === 1) {
+            if (
+                get_config('format_mooin4', "certificates")
+                && get_toggle_certificate_visibility($courseid) === 1
+                && get_config('format_mooin4', "toggle_global_certificate_visibility")
+            ) {
                 $data['certificates'] = [
                     'url' => $certificatesUrl,
                     'active' => $this->check_if_active($certificatesUrl),
                 ];
             }
 
-            if (get_config('format_mooin4', "discussions") && get_toggle_discussion_visibility($courseid) === 1) {
+            if (
+                get_config('format_mooin4', "discussions")
+                && get_toggle_discussion_visibility($courseid) === 1
+                && get_config('format_mooin4', "toggle_global_discussion_visibility")
+            ) {
                 $data['discussions'] = [
                     'url' => $discussionsUrl,
                     'active' => $this->check_if_active($discussionsUrl),
@@ -164,6 +176,7 @@ class renderer extends section_renderer {
                 $has_capability
                 && get_config('format_mooin4', 'participants')
                 && get_toggle_userlist_visibility($courseid) === 1
+                && get_config('format_mooin4', 'toggle_global_userlist_visibility') === 1
             ) {
                 $data['participants'] = [
                     'url' => $participantsUrl,

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -29,8 +29,7 @@ use format_mooin4\local\utils as utils;
  * @copyright 2012 Dan Poltawski
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class renderer extends section_renderer
-{
+class renderer extends section_renderer {
 
     /**
      * Constructor method, calls the parent constructor.
@@ -38,8 +37,7 @@ class renderer extends section_renderer
      * @param moodle_page $page
      * @param string $target one of rendering target constants
      */
-    public function __construct(moodle_page $page, $target)
-    {
+    public function __construct(moodle_page $page, $target) {
         parent::__construct($page, $target);
 
         // Since format_mooin4_renderer::section_edit_control_items() only displays the 'Highlight' control
@@ -55,8 +53,7 @@ class renderer extends section_renderer
      * @param stdClass $course The course entry from DB
      * @return string HTML to output.
      */
-    public function section_title($section, $course)
-    {
+    public function section_title($section, $course) {
         return $this->render(course_get_format($course)->inplace_editable_render_section_name($section));
     }
 
@@ -67,8 +64,7 @@ class renderer extends section_renderer
      * @param int|stdClass $course The course entry from DB
      * @return string HTML to output.
      */
-    public function section_title_without_link($section, $course)
-    {
+    public function section_title_without_link($section, $course) {
         return $this->render(course_get_format($course)->inplace_editable_render_section_name($section, false));
     }
 
@@ -83,8 +79,7 @@ class renderer extends section_renderer
      * @param course_format $format the course format
      * @return String the course index HTML.
      */
-    public function course_index_drawer(course_format $format): ?String
-    {
+    public function course_index_drawer(course_format $format): ?String {
         global $DB;
 
         if ($format->uses_course_index()) {
@@ -97,24 +92,52 @@ class renderer extends section_renderer
             $discussionsUrl = new moodle_url('/course/format/mooin4/all_discussionforums.php', array('id' => $course->id));
             $participantsUrl = new moodle_url('/course/format/mooin4/participants.php', array('id' => $course->id));
             $coursecompetenciesUrl = new moodle_url('/admin/tool/lp/coursecompetencies.php', array('courseid' => $course->id, 'mod' => 0));
-            
+
             $newsforumUrl = null;
-            
+
             if ($forum = $DB->get_record('forum', array('course' => $course->id, 'type' => 'news'))) {
                 if ($module = $DB->get_record('modules', array('name' => 'forum'))) {
                     if ($cm = $DB->get_record('course_modules', array('module' => $module->id, 'instance' => $forum->id))) {
                         $newsforumUrl = new moodle_url('/mod/forum/view.php', array('id' => $cm->id));
-                    } 
+                    }
                 }
-            } 
-           
+            }
+
             $data = [
                 'coursename' => $course->shortname,
                 'overview' => ['url' => $overview, 'active' => $this->check_if_active($overview)],
                 'unenrolurl' => utils::get_unenrol_url($course->id),
             ];
-    
-            
+
+
+
+            //check course settings 
+            require_once(__DIR__ . '/../../../../lib.php');
+            $courseid = $course->id;
+            if (get_config('format_mooin4', "badges") && get_toggle_badge_visibility($courseid) === 1) {
+                $data['badges'] = [
+                    'url' => $badgesUrl,
+                    'active' => $this->check_if_active($badgesUrl),
+                ];
+            }
+
+            if (get_config('format_mooin4', "certificates") && get_toggle_certificate_visibility($courseid) === 1) {
+                $data['certificates'] = [
+                    'url' => $certificatesUrl,
+                    'active' => $this->check_if_active($certificatesUrl),
+                ];
+            }
+
+            if (get_config('format_mooin4', "discussions") && get_toggle_discussion_visibility($courseid) === 1) {
+                $data['discussions'] = [
+                    'url' => $discussionsUrl,
+                    'active' => $this->check_if_active($discussionsUrl),
+                ];
+            }
+
+            //check global settings
+
+            /*
             // Define the settings and corresponding URLs.
             $features = [
                 'badges' => $badgesUrl,
@@ -122,29 +145,39 @@ class renderer extends section_renderer
                 'discussions' => $discussionsUrl,
                 'coursecompetencies' => $coursecompetenciesUrl,
             ];
-            
             // Loop through each feature, adding it if the setting is enabled.
             foreach ($features as $key => $url) {
-                if (get_config('format_mooin4', $key)) {
+                if (get_config('format_mooin4', $key) && isset($url)) {
                     $data[$key] = [
                         'url' => $url,
                         'active' => $this->check_if_active($url)
                     ];
+                } else {
+                    unset($data[$key]);
                 }
             }
             
+            */
             $context = context_course::instance($course->id);
             $has_capability = has_capability('moodle/course:viewparticipants', $context);
-            if ($has_capability && get_config('format_mooin4', 'participants') ) {
+            if (
+                $has_capability
+                && get_config('format_mooin4', 'participants')
+                && get_toggle_userlist_visibility($courseid) === 1
+            ) {
                 $data['participants'] = [
                     'url' => $participantsUrl,
                     'active' => $this->check_if_active($participantsUrl)
                 ];
             }
 
-            if (!is_null($newsforumUrl) && get_config('format_mooin4', 'news') ) {
+            if (
+                !is_null($newsforumUrl)
+                && get_config('format_mooin4', 'news')
+                && get_toggle_newssection_visibility($courseid) === 1
+            ) {
                 $data['newsforum'] = [
-                    'url' => $newsforumUrl, 
+                    'url' => $newsforumUrl,
                     'active' => $this->check_if_active($newsforumUrl),
                 ];
             }
@@ -153,15 +186,13 @@ class renderer extends section_renderer
         return '';
     }
 
-    function check_if_active($url)
-    {
+    function check_if_active($url) {
         global $PAGE;
         if ($url !== null) {
             if ($PAGE->url->compare($url, URL_MATCH_EXACT)) {
                 //if ($PAGE->url instanceof moodle_url && $url instanceof moodle_url) {
                 return true;
-            }
-            else {
+            } else {
                 return false;
             }
         } else {
@@ -169,28 +200,27 @@ class renderer extends section_renderer
         }
     }
 
-    function course_section_add_cm_control($course, $section, $sectionreturn = null, $displayoptions = array())
-    {
+    function course_section_add_cm_control($course, $section, $sectionreturn = null, $displayoptions = array()) {
         $singlesection = course_get_format($course)->get_sectionnum();
         // Mod tinjohn - not sure why it is permitted for a a course overview. 
         //if ($singlesection) {
-            if (
-                !has_capability('moodle/course:manageactivities', context_course::instance($course->id))
-                || !$this->page->user_is_editing()
-            ) {
-                return '';
-            }
+        if (
+            !has_capability('moodle/course:manageactivities', context_course::instance($course->id))
+            || !$this->page->user_is_editing()
+        ) {
+            return '';
+        }
 
-            $data = [
-                'sectionid' => $section,
-                'sectionreturn' => $sectionreturn
-            ];
-            $ajaxcontrol = $this->render_from_template('course/activitychooserbutton', $data);
+        $data = [
+            'sectionid' => $section,
+            'sectionreturn' => $sectionreturn
+        ];
+        $ajaxcontrol = $this->render_from_template('course/activitychooserbutton', $data);
 
-            // Load the JS for the modal.
-            $this->course_activitychooser($course->id);
+        // Load the JS for the modal.
+        $this->course_activitychooser($course->id);
 
-            return $ajaxcontrol;
+        return $ajaxcontrol;
         //}
     }
 }

--- a/format.js
+++ b/format.js
@@ -16,7 +16,7 @@ M.course.format = M.course.format || {};
  *
  * @return {object} section list configuration
  */
-M.course.format.get_config = function() {
+M.course.format.get_config = function () {
     return {
         container_node: 'ul',
         container_class: 'topics',
@@ -32,7 +32,7 @@ M.course.format.get_config = function() {
  * @param {string} node1 node to swap to
  * @param {string} node2 node to swap with
  */
-M.course.format.swap_sections = function(Y, node1, node2) {
+M.course.format.swap_sections = function (Y, node1, node2) {
     var CSS = {
         COURSECONTENT: 'course-content',
         SECTIONADDMENUS: 'section_add_menus'
@@ -54,13 +54,13 @@ M.course.format.swap_sections = function(Y, node1, node2) {
  * @param {string} sectionfrom first affected section
  * @param {string} sectionto last affected section
  */
-M.course.format.process_sections = function(Y, sectionlist, response, sectionfrom, sectionto) {
+M.course.format.process_sections = function (Y, sectionlist, response, sectionfrom, sectionto) {
     var CSS = {
         SECTIONNAME: 'sectionname'
     },
-    SELECTORS = {
-        SECTIONLEFTSIDE: '.left .section-handle .icon'
-    };
+        SELECTORS = {
+            SECTIONLEFTSIDE: '.left .section-handle .icon'
+        };
 
     if (response.action == 'move') {
         // If moving up swap around 'sectionfrom' and 'sectionto' so the that loop operates.
@@ -88,3 +88,37 @@ M.course.format.process_sections = function(Y, sectionlist, response, sectionfro
         }
     }
 };
+
+document.addEventListener("DOMContentLoaded", function () {
+    if (window.location.href.indexOf("admin/settings.php?section=formatsettingmooin4") > -1) {
+        function toggleDisableCheckbox(masterId, dependentId) {
+            const master = document.getElementById(masterId);
+            const dependent = document.getElementById(dependentId);
+
+            if (!master || !dependent) return;
+
+            // Funktion zur Aktualisierung des Zustands
+            function updateState() {
+                if (master.checked) {
+                    dependent.disabled = false;
+                    dependent.checked = true;
+                } else {
+                    dependent.checked = false;
+                    dependent.disabled = true;
+                }
+            }
+
+            // Anfangszustand setzen
+            updateState();
+
+            // Eventlistener setzen
+            master.addEventListener("change", updateState);
+        }
+
+        toggleDisableCheckbox("id_s_format_mooin4_toggle_global_badge_visibility", "id_s_format_mooin4_badges");
+        toggleDisableCheckbox("id_s_format_mooin4_toggle_global_certificate_visibility", "id_s_format_mooin4_certificates");
+        toggleDisableCheckbox("id_s_format_mooin4_toggle_global_discussion_visibility", "id_s_format_mooin4_discussions");
+        toggleDisableCheckbox("id_s_format_mooin4_toggle_global_userlist_visibility", "id_s_format_mooin4_participants");
+
+    }
+});

--- a/lang/de/format_mooin4.php
+++ b/lang/de/format_mooin4.php
@@ -201,3 +201,22 @@ $string['indentation_help'] = 'Erlauben Sie Lehrern und anderen Benutzern mit de
 
 // course side bar
 $string['include_in_sidebar'] = "In der Seitenleite anzeigen";
+
+//course menu settings
+$string['toggle_newssection_visibility'] = 'News-Bereich anzeigen';
+$string['toggle_newssection_visibility_help'] = 'Wenn aktiviert, wird der Newsbereich mit einem Preview des neuesten Newsbeitrags angezeigt.';
+
+$string['toggle_progressbar_visibility'] = 'Progressbar anzeigen';
+$string['toggle_progressbar_visibility_help'] = 'Wenn aktiviert, wird der Progressbar angezeigt.';
+
+$string['toggle_badge_visibility'] = 'Badge-Kachel anzeigen';
+$string['toggle_badge_visibility_help'] = 'Wenn aktiviert, wird die Badge-Kachel im Kurs angezeigt.';
+
+$string['toggle_certificate_visibility'] = 'Zertifikate-Kachel anzeigen';
+$string['toggle_certificate_visibility_help'] = 'Wenn aktiviert, wird die Zertifikatskachel im Kurs angezeigt.';
+
+$string['toggle_discussion_visibility'] = 'Diskussionskachel anzeigen';
+$string['toggle_discussion_visibility_help'] = 'Wenn aktiviert, wird die Diskussionskachel im Community-Bereich angezeigt.';
+
+$string['toggle_userlist_visibility'] = 'User-Liste anzeigen';
+$string['toggle_userlist_visibility_help'] = 'Wenn aktiviert, wird die User-Liste der neu hinzugekommenen User im Community-Bereich angezeigt.';

--- a/lang/de/format_mooin4.php
+++ b/lang/de/format_mooin4.php
@@ -200,7 +200,12 @@ $string['indentation'] = 'Einzug auf der Kursseite erlauben';
 $string['indentation_help'] = 'Erlauben Sie Lehrern und anderen Benutzern mit der Berechtigung zur Verwaltung von Aktivitäten, Elemente auf der Kursseite einzurücken.';
 
 // course side bar
-$string['include_in_sidebar'] = "In der Seitenleite anzeigen";
+$string['include_in_sidebar'] = "Links im Kursindex anzeigen";
+$string['global_tile_visibility'] = 'mooin-Kacheln global verfügbar (Kursstartseite)';
+$string['toggle_global_badge_visibility'] = 'Badge-Kachel global verfügbar';
+$string['toggle_global_certificate_visibility'] = 'Zertifikatskachel global verfügbar';
+$string['toggle_global_discussion_visibility'] = 'Diskussionskachel global verfügbar';
+$string['toggle_global_userlist_visibility'] = 'Userliste-Kachel global verfügbar';
 
 //course menu settings
 $string['toggle_courseindex_visibility'] = 'Kursindex anzeigen';

--- a/lang/de/format_mooin4.php
+++ b/lang/de/format_mooin4.php
@@ -200,12 +200,12 @@ $string['indentation'] = 'Einzug auf der Kursseite erlauben';
 $string['indentation_help'] = 'Erlauben Sie Lehrern und anderen Benutzern mit der Berechtigung zur Verwaltung von Aktivitäten, Elemente auf der Kursseite einzurücken.';
 
 // course side bar
-$string['include_in_sidebar'] = "Links im Kursindex anzeigen";
-$string['global_tile_visibility'] = 'mooin-Kacheln global verfügbar (Kursstartseite)';
-$string['toggle_global_badge_visibility'] = 'Badge-Kachel global verfügbar';
-$string['toggle_global_certificate_visibility'] = 'Zertifikatskachel global verfügbar';
-$string['toggle_global_discussion_visibility'] = 'Diskussionskachel global verfügbar';
-$string['toggle_global_userlist_visibility'] = 'Userliste-Kachel global verfügbar';
+$string['include_in_sidebar'] = "Links im Kursindex anzeigen (nur verfügbar, wenn global aktiviert)";
+$string['global_tile_visibility'] = 'mooin-Kacheln und Links im Kursindex global verfügbar (Kursstartseite)';
+$string['toggle_global_badge_visibility'] = 'Badge-Kachel und Kursindexlink global verfügbar';
+$string['toggle_global_certificate_visibility'] = 'Zertifikatskachel und Kursindexlink global verfügbar';
+$string['toggle_global_discussion_visibility'] = 'Diskussionskachel und Kursindexlink global verfügbar';
+$string['toggle_global_userlist_visibility'] = 'Userliste-Kachel und Kursindexlink global verfügbar';
 
 //course menu settings
 $string['toggle_courseindex_visibility'] = 'Kursindex anzeigen';

--- a/lang/de/format_mooin4.php
+++ b/lang/de/format_mooin4.php
@@ -220,3 +220,6 @@ $string['toggle_discussion_visibility_help'] = 'Wenn aktiviert, wird die Diskuss
 
 $string['toggle_userlist_visibility'] = 'User-Liste anzeigen';
 $string['toggle_userlist_visibility_help'] = 'Wenn aktiviert, wird die User-Liste der neu hinzugekommenen User im Community-Bereich angezeigt.';
+
+$string['only_badges'] = 'Badges';
+$string['only_certificates'] = 'Zertifikate';

--- a/lang/de/format_mooin4.php
+++ b/lang/de/format_mooin4.php
@@ -203,6 +203,9 @@ $string['indentation_help'] = 'Erlauben Sie Lehrern und anderen Benutzern mit de
 $string['include_in_sidebar'] = "In der Seitenleite anzeigen";
 
 //course menu settings
+$string['toggle_courseindex_visibility'] = 'Kursindex anzeigen';
+$string['toggle_courseindex_visibility_help'] = 'Wenn aktiviert, wird der Kursindex auf der linken Seite angezeigt.';
+
 $string['toggle_newssection_visibility'] = 'News-Bereich anzeigen';
 $string['toggle_newssection_visibility_help'] = 'Wenn aktiviert, wird der Newsbereich mit einem Preview des neuesten Newsbeitrags angezeigt.';
 

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -197,7 +197,13 @@ $string['youareeditingsection'] = 'Warning: You are editing Section 0!';
 $string['mycoursecompetencies'] = 'My course competencies';
 
 // course side bar
-$string['include_in_sidebar'] = 'Display in sidebar';
+$string['include_in_sidebar'] = 'Display links in course index';
+$string['global_tile_visibility'] = 'Display mooin tiles in course globally';
+$string['toggle_global_badge_visibility'] = 'Toggle global badge tile visibility';
+$string['toggle_global_certificate_visibility'] = 'Toggle global certificate tile visibility';
+$string['toggle_global_discussion_visibility'] = 'Toggle global discussion tile visibility';
+$string['toggle_global_userlist_visibility'] = 'Toggle global userlist tile visibility';
+
 
 //course menu settings
 $string['toggle_courseindex_visibility'] = 'Show Course Index';

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -220,3 +220,7 @@ $string['toggle_userlist_visibility_help'] = 'When activated, the user list of t
 
 $string['only_badges'] = 'Badges';
 $string['only_certificates'] = 'Certificates';
+
+$string['indentation_help'] = 'Allow teachers and other users with permission to manage activities to indent items on the course page.';
+$string['indentation'] = 'Allow indentation on the course page';
+

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -198,11 +198,11 @@ $string['mycoursecompetencies'] = 'My course competencies';
 
 // course side bar
 $string['include_in_sidebar'] = 'Display links in course index';
-$string['global_tile_visibility'] = 'Display mooin tiles in course globally';
-$string['toggle_global_badge_visibility'] = 'Toggle global badge tile visibility';
-$string['toggle_global_certificate_visibility'] = 'Toggle global certificate tile visibility';
-$string['toggle_global_discussion_visibility'] = 'Toggle global discussion tile visibility';
-$string['toggle_global_userlist_visibility'] = 'Toggle global userlist tile visibility';
+$string['global_tile_visibility'] = 'Display mooin tiles and links in course index in course globally';
+$string['toggle_global_badge_visibility'] = 'Toggle global badge tile and course index link visibility';
+$string['toggle_global_certificate_visibility'] = 'Toggle global certificate tile and course index link visibility';
+$string['toggle_global_discussion_visibility'] = 'Toggle global discussion tile and course index link visibility';
+$string['toggle_global_userlist_visibility'] = 'Toggle global userlist tile and course index link visibility';
 
 
 //course menu settings

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -200,6 +200,9 @@ $string['mycoursecompetencies'] = 'My course competencies';
 $string['include_in_sidebar'] = 'Display in sidebar';
 
 //course menu settings
+$string['toggle_courseindex_visibility'] = 'Show Course Index';
+$string['toggle_courseindex_visibility_help'] = 'When activated, the course index is displayed in the course.';
+
 $string['toggle_newssection_visibility'] = 'Show News Section with Post-Preview';
 $string['toggle_newssection_visibility_help'] = 'When activated, the news section with preview of the last post is displayed in the course.';
 

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -199,3 +199,23 @@ $string['mycoursecompetencies'] = 'My course competencies';
 // course side bar
 $string['include_in_sidebar'] = 'Display in sidebar';
 
+//course menu settings
+$string['toggle_newssection_visibility'] = 'Show News Section with Post-Preview';
+$string['toggle_newssection_visibility_help'] = 'When activated, the news section with preview of the last post is displayed in the course.';
+
+$string['toggle_progressbar_visibility'] = 'Show Progressbar';
+$string['toggle_progressbar_visibility_help'] = 'When activated, the progress bar is displayed in the course.';
+
+$string['toggle_badge_visibility'] = 'Show Badge Tile';
+$string['toggle_badge_visibility_help'] = 'When activated, the badge tile is displayed in the course.';
+
+$string['toggle_certificate_visibility'] = 'Show Certificate Tile';
+$string['toggle_certificate_visibility_help'] = 'When activated, the certificate tile is displayed in the course.';
+
+$string['toggle_discussion_visibility'] = 'Show Discussion Tile in Community Section';
+$string['toggle_discussion_visibility_help'] = 'When activated, the discussion tile is displayed in the community tile.';
+
+$string['toggle_userlist_visibility'] = 'Show User List in Community Section';
+$string['toggle_userlist_visibility_help'] = 'When activated, the user list of the last attending users is displayed in the community tile.';
+
+

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -218,4 +218,5 @@ $string['toggle_discussion_visibility_help'] = 'When activated, the discussion t
 $string['toggle_userlist_visibility'] = 'Show User List in Community Section';
 $string['toggle_userlist_visibility_help'] = 'When activated, the user list of the last attending users is displayed in the community tile.';
 
-
+$string['only_badges'] = 'Badges';
+$string['only_certificates'] = 'Certificates';

--- a/lang/en/format_mooin4.php
+++ b/lang/en/format_mooin4.php
@@ -197,7 +197,7 @@ $string['youareeditingsection'] = 'Warning: You are editing Section 0!';
 $string['mycoursecompetencies'] = 'My course competencies';
 
 // course side bar
-$string['include_in_sidebar'] = 'Display links in course index';
+$string['include_in_sidebar'] = 'Display links in course index (only available when globally activated)';
 $string['global_tile_visibility'] = 'Display mooin tiles and links in course index in course globally';
 $string['toggle_global_badge_visibility'] = 'Toggle global badge tile and course index link visibility';
 $string['toggle_global_certificate_visibility'] = 'Toggle global certificate tile and course index link visibility';

--- a/lib.php
+++ b/lib.php
@@ -1078,3 +1078,15 @@ function get_toggle_section_number_visibility($courseid) {
         return $courseformatoptions['toggle_section_number_visibility']['default'];
     }
 }
+
+function get_toggle_newssection_visibility($courseid) {
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_newssection_visibility'])) {
+        return $formatoptions['toggle_newssection_visibility'];
+    } else {
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_newssection_visibility']['default'];
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -1114,3 +1114,15 @@ function get_toggle_discussion_visibility($courseid) {
         return $courseformatoptions['toggle_discussion_visibility']['default'];
     }
 }
+
+function get_toggle_badge_visibility($courseid) {
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_badge_visibility'])) {
+        return $formatoptions['toggle_badge_visibility'];
+    } else {
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_badge_visibility']['default'];
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -1126,3 +1126,27 @@ function get_toggle_badge_visibility($courseid) {
         return $courseformatoptions['toggle_badge_visibility']['default'];
     }
 }
+
+function get_toggle_certificate_visibility($courseid) {
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_certificate_visibility'])) {
+        return $formatoptions['toggle_certificate_visibility'];
+    } else {
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_certificate_visibility']['default'];
+    }
+}
+
+function get_toggle_userlist_visibility($courseid) {
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_userlist_visibility'])) {
+        return $formatoptions['toggle_userlist_visibility'];
+    } else {
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_userlist_visibility']['default'];
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -52,7 +52,13 @@ class format_mooin4 extends core_courseformat\base {
     }
 
     public function uses_course_index() {
-        return true;
+        $course = $this->get_course();
+        $courseid = $course->id;
+        if (get_toggle_courseindex_visibility($courseid) === 1) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public function uses_indentation(): bool {
@@ -614,7 +620,7 @@ class format_mooin4 extends core_courseformat\base {
      */
     public function update_course_format_options($data, $oldcourse = null) {
         global $DB;
-        
+
         // Function update_course_format_options for format_topics_test.php only.
         if (!$oldcourse) {
             // Add first chapter, there must be no sections without parent chapter
@@ -923,6 +929,10 @@ class format_mooin4 extends core_courseformat\base {
                     'default' => 1,  // Standardwert (0 = nicht ausgewählt)
                     'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
                 ],
+                'toggle_courseindex_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
                 'toggle_newssection_visibility' => [
                     'default' => 1,  // Standardwert (0 = nicht ausgewählt)
                     'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
@@ -958,42 +968,48 @@ class format_mooin4 extends core_courseformat\base {
                         'help' => 'toggle_section_number_visibility',
                         'help_component' => 'format_mooin4',
                     ],
+                    'toggle_courseindex_visibility' => [
+                        'label' => new lang_string('toggle_courseindex_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_courseindex_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
                     'toggle_newssection_visibility' => [
-                    'label' => new lang_string('toggle_newssection_visibility', 'format_mooin4'),
-                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                    'help' => 'toggle_newssection_visibility',
-                    'help_component' => 'format_mooin4',
-                ],
-                'toggle_progressbar_visibility' => [
-                    'label' => new lang_string('toggle_progressbar_visibility', 'format_mooin4'),
-                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                    'help' => 'toggle_progressbar_visibility',
-                    'help_component' => 'format_mooin4',
-                ],
-                'toggle_badge_visibility' => [
-                    'label' => new lang_string('toggle_badge_visibility', 'format_mooin4'),
-                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                    'help' => 'toggle_badge_visibility',
-                    'help_component' => 'format_mooin4',
-                ],
-                'toggle_certificate_visibility' => [
-                    'label' => new lang_string('toggle_certificate_visibility', 'format_mooin4'),
-                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                    'help' => 'toggle_certificate_visibility',
-                    'help_component' => 'format_mooin4',
-                ],
-                'toggle_discussion_visibility' => [
-                    'label' => new lang_string('toggle_discussion_visibility', 'format_mooin4'),
-                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                    'help' => 'toggle_discussion_visibility',
-                    'help_component' => 'format_mooin4',
-                ],
-                'toggle_userlist_visibility' => [
-                    'label' => new lang_string('toggle_userlist_visibility', 'format_mooin4'),
-                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                    'help' => 'toggle_userlist_visibility',
-                    'help_component' => 'format_mooin4',
-                ],
+                        'label' => new lang_string('toggle_newssection_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_newssection_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
+                    'toggle_progressbar_visibility' => [
+                        'label' => new lang_string('toggle_progressbar_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_progressbar_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
+                    'toggle_badge_visibility' => [
+                        'label' => new lang_string('toggle_badge_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_badge_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
+                    'toggle_certificate_visibility' => [
+                        'label' => new lang_string('toggle_certificate_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_certificate_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
+                    'toggle_discussion_visibility' => [
+                        'label' => new lang_string('toggle_discussion_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_discussion_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
+                    'toggle_userlist_visibility' => [
+                        'label' => new lang_string('toggle_userlist_visibility', 'format_mooin4'),
+                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                        'help' => 'toggle_userlist_visibility',
+                        'help_component' => 'format_mooin4',
+                    ],
                 ];
                 $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
             }
@@ -1148,5 +1164,17 @@ function get_toggle_userlist_visibility($courseid) {
     } else {
         $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
         return $courseformatoptions['toggle_userlist_visibility']['default'];
+    }
+}
+
+function get_toggle_courseindex_visibility($courseid) {
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_courseindex_visibility'])) {
+        return $formatoptions['toggle_courseindex_visibility'];
+    } else {
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_courseindex_visibility']['default'];
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -923,6 +923,30 @@ class format_mooin4 extends core_courseformat\base {
                     'default' => 1,  // Standardwert (0 = nicht ausgewählt)
                     'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
                 ],
+                'toggle_newssection_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
+                'toggle_progressbar_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
+                'toggle_badge_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
+                'toggle_certificate_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
+                'toggle_discussion_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
+                'toggle_userlist_visibility' => [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+                ],
             ];
         }
         if ($foreditform) {
@@ -934,6 +958,42 @@ class format_mooin4 extends core_courseformat\base {
                         'help' => 'toggle_section_number_visibility',
                         'help_component' => 'format_mooin4',
                     ],
+                    'toggle_newssection_visibility' => [
+                    'label' => new lang_string('toggle_newssection_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_newssection_visibility',
+                    'help_component' => 'format_mooin4',
+                ],
+                'toggle_progressbar_visibility' => [
+                    'label' => new lang_string('toggle_progressbar_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_progressbar_visibility',
+                    'help_component' => 'format_mooin4',
+                ],
+                'toggle_badge_visibility' => [
+                    'label' => new lang_string('toggle_badge_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_badge_visibility',
+                    'help_component' => 'format_mooin4',
+                ],
+                'toggle_certificate_visibility' => [
+                    'label' => new lang_string('toggle_certificate_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_certificate_visibility',
+                    'help_component' => 'format_mooin4',
+                ],
+                'toggle_discussion_visibility' => [
+                    'label' => new lang_string('toggle_discussion_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_discussion_visibility',
+                    'help_component' => 'format_mooin4',
+                ],
+                'toggle_userlist_visibility' => [
+                    'label' => new lang_string('toggle_userlist_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_userlist_visibility',
+                    'help_component' => 'format_mooin4',
+                ],
                 ];
                 $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
             }

--- a/lib.php
+++ b/lib.php
@@ -1102,3 +1102,15 @@ function get_toggle_progressbar_visibility($courseid) {
         return $courseformatoptions['toggle_progressbar_visibility']['default'];
     }
 }
+
+function get_toggle_discussion_visibility($courseid) {
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_discussion_visibility'])) {
+        return $formatoptions['toggle_discussion_visibility'];
+    } else {
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_discussion_visibility']['default'];
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -941,79 +941,98 @@ class format_mooin4 extends core_courseformat\base {
                     'default' => 1,  // Standardwert (0 = nicht ausgewählt)
                     'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
                 ],
-                'toggle_badge_visibility' => [
-                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
-                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
-                ],
-                'toggle_certificate_visibility' => [
-                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
-                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
-                ],
-                'toggle_discussion_visibility' => [
-                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
-                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
-                ],
-                'toggle_userlist_visibility' => [
-                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
-                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
-                ],
             ];
+            if (get_config('format_mooin4', "toggle_global_badge_visibility") == 1) {
+                $courseformatoptions['toggle_badge_visibility'] = [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+
+                ];
+            }
+            if (get_config('format_mooin4', "toggle_global_certificate_visibility") == 1) {
+                $courseformatoptions['toggle_certificate_visibility'] = [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+
+                ];
+            }
+            if (get_config('format_mooin4', "toggle_global_discussion_visibility") == 1) {
+                $courseformatoptions['toggle_discussion_visibility'] = [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+
+                ];
+            }
+            if (get_config('format_mooin4', "toggle_global_userlist_visibility") == 1) {
+                $courseformatoptions['toggle_userlist_visibility'] = [
+                    'default' => 1,  // Standardwert (0 = nicht ausgewählt)
+                    'type' => PARAM_BOOL,  // Boolean-Wert (Checkbox)
+
+                ];
+            }
         }
         if ($foreditform) {
             if (!isset($courseformatoptions['toggle_section_number_visibility']['label'])) {
-                $courseformatoptionsedit = [
-                    'toggle_section_number_visibility' => [
-                        'label' => new lang_string('toggle_section_number_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_section_number_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
-                    'toggle_courseindex_visibility' => [
-                        'label' => new lang_string('toggle_courseindex_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_courseindex_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
-                    'toggle_newssection_visibility' => [
-                        'label' => new lang_string('toggle_newssection_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_newssection_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
-                    'toggle_progressbar_visibility' => [
-                        'label' => new lang_string('toggle_progressbar_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_progressbar_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
-                    'toggle_badge_visibility' => [
-                        'label' => new lang_string('toggle_badge_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_badge_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
-                    'toggle_certificate_visibility' => [
-                        'label' => new lang_string('toggle_certificate_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_certificate_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
-                    'toggle_discussion_visibility' => [
-                        'label' => new lang_string('toggle_discussion_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_discussion_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
-                    'toggle_userlist_visibility' => [
-                        'label' => new lang_string('toggle_userlist_visibility', 'format_mooin4'),
-                        'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
-                        'help' => 'toggle_userlist_visibility',
-                        'help_component' => 'format_mooin4',
-                    ],
+                $courseformatoptionsedit['toggle_section_number_visibility'] = [
+                    'label' => new lang_string('toggle_section_number_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_section_number_visibility',
+                    'help_component' => 'format_mooin4',
                 ];
-                $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
             }
+            $courseformatoptionsedit['toggle_courseindex_visibility'] = [
+                'label' => new lang_string('toggle_courseindex_visibility', 'format_mooin4'),
+                'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                'help' => 'toggle_courseindex_visibility',
+                'help_component' => 'format_mooin4',
+            ];
+            $courseformatoptionsedit['toggle_newssection_visibility'] = [
+                'label' => new lang_string('toggle_newssection_visibility', 'format_mooin4'),
+                'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                'help' => 'toggle_newssection_visibility',
+                'help_component' => 'format_mooin4',
+            ];
+            $courseformatoptionsedit['toggle_progressbar_visibility'] = [
+                'label' => new lang_string('toggle_progressbar_visibility', 'format_mooin4'),
+                'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                'help' => 'toggle_progressbar_visibility',
+                'help_component' => 'format_mooin4',
+            ];
+            if (get_config('format_mooin4', "toggle_global_badge_visibility") == 1) {
+                $courseformatoptionsedit['toggle_badge_visibility'] = [
+                    'label' => new lang_string('toggle_badge_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_badge_visibility',
+                    'help_component' => 'format_mooin4',
+                ];
+            }
+            if (get_config('format_mooin4', "toggle_global_certificate_visibility") == 1) {
+                $courseformatoptionsedit['toggle_certificate_visibility'] = [
+                    'label' => new lang_string('toggle_certificate_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_certificate_visibility',
+                    'help_component' => 'format_mooin4',
+                ];
+            }
+            if (get_config('format_mooin4', "toggle_global_discussion_visibility") == 1) {
+                $courseformatoptionsedit['toggle_discussion_visibility'] = [
+                    'label' => new lang_string('toggle_discussion_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_discussion_visibility',
+                    'help_component' => 'format_mooin4',
+                ];
+            }
+            if (get_config('format_mooin4', "toggle_global_userlist_visibility") == 1) {
+                $courseformatoptionsedit['toggle_userlist_visibility'] = [
+                    'label' => new lang_string('toggle_userlist_visibility', 'format_mooin4'),
+                    'element_type' => 'advcheckbox',  // Checkbox-Typ für das Bearbeitungsformular
+                    'help' => 'toggle_userlist_visibility',
+                    'help_component' => 'format_mooin4',
+                ];
+            }
+            $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
         }
+
         return $courseformatoptions;
     }
 }
@@ -1120,6 +1139,9 @@ function get_toggle_progressbar_visibility($courseid) {
 }
 
 function get_toggle_discussion_visibility($courseid) {
+    if (get_config('format_mooin4', "toggle_global_discussion_visibility") != 1) {
+        return 0; // oder false – je nach gewünschtem Verhalten
+    }
     $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
     $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
     // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
@@ -1132,6 +1154,9 @@ function get_toggle_discussion_visibility($courseid) {
 }
 
 function get_toggle_badge_visibility($courseid) {
+    if (get_config('format_mooin4', "toggle_global_badge_visibility") != 1) {
+        return 0; // oder false – je nach gewünschtem Verhalten
+    }
     $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
     $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
     // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
@@ -1144,6 +1169,9 @@ function get_toggle_badge_visibility($courseid) {
 }
 
 function get_toggle_certificate_visibility($courseid) {
+    if (get_config('format_mooin4', "toggle_global_certificate_visibility") != 1) {
+        return 0; // oder false – je nach gewünschtem Verhalten
+    }
     $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
     $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
     // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
@@ -1156,6 +1184,9 @@ function get_toggle_certificate_visibility($courseid) {
 }
 
 function get_toggle_userlist_visibility($courseid) {
+    if (get_config('format_mooin4', "toggle_global_userlist_visibility") != 1) {
+        return 0; // oder false – je nach gewünschtem Verhalten
+    }
     $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
     $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
     // Überprüfen, ob die benutzerdefinierte Option gesetzt ist

--- a/lib.php
+++ b/lib.php
@@ -107,7 +107,7 @@ class format_mooin4 extends core_courseformat\base {
      * @return string the page title
      */
     public function page_title(): string {
-        return get_string('topicoutline');
+        return get_string('topicoutline', 'format_mooin4');
     }
 
     /**

--- a/lib.php
+++ b/lib.php
@@ -1090,3 +1090,15 @@ function get_toggle_newssection_visibility($courseid) {
         return $courseformatoptions['toggle_newssection_visibility']['default'];
     }
 }
+
+function get_toggle_progressbar_visibility($courseid) {
+    $format = course_get_format($courseid); // Holt das Format für den aktuellen Kurs
+    $formatoptions = $format->get_format_options(); // Holt alle Kursformatoptionen
+    // Überprüfen, ob die benutzerdefinierte Option gesetzt ist
+    if (isset($formatoptions['toggle_progressbar_visibility'])) {
+        return $formatoptions['toggle_progressbar_visibility'];
+    } else {
+        $courseformatoptions = $format->course_format_options(false); // Standardoptionen holen
+        return $courseformatoptions['toggle_progressbar_visibility']['default'];
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -33,4 +33,46 @@ if ($ADMIN->fulltree) {
         new lang_string('indentation_help', 'format_mooin4').'<br />'.$link,
         1
     ));
+
+    // Add a headline "Include in Navigation"
+    $settings->add(new admin_setting_heading(
+        'format_mooin4/include_in_navigation',
+        get_string('include_in_sidebar', 'format_mooin4'),
+        ''
+    ));
+
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/news',
+        new lang_string('news', 'format_mooin4'), "",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/badges',
+        new lang_string('badges', 'format_mooin4'), "",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/certificates',
+        new lang_string('certificates', 'format_mooin4'),"",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/coursecompetencies',
+        new lang_string('coursecompetencies', 'tool_lp'),"",
+        0
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/discussions',
+        new lang_string('discussions', 'format_mooin4'),"",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/participants',
+        new lang_string('participants', 'format_mooin4'),"",
+        1
+    ));
+
+
+
+
 }

--- a/settings.php
+++ b/settings.php
@@ -36,6 +36,34 @@ if ($ADMIN->fulltree) {
 
     // Add a headline "Include in Navigation"
     $settings->add(new admin_setting_heading(
+        'format_mooin4/global_tile_visibility',
+        get_string('global_tile_visibility', 'format_mooin4'),
+        ''
+    ));
+
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_badge_visibility',
+        new lang_string('toggle_global_badge_visibility', 'format_mooin4'), "",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_certificate_visibility',
+        new lang_string('toggle_global_certificate_visibility', 'format_mooin4'), "",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_discussion_visibility',
+        new lang_string('toggle_global_discussion_visibility', 'format_mooin4'),"",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_userlist_visibility',
+        new lang_string('toggle_global_userlist_visibility', 'format_mooin4'),"",
+        1
+    ));
+   
+    // Add a headline "Include in Navigation"
+    $settings->add(new admin_setting_heading(
         'format_mooin4/include_in_navigation',
         get_string('include_in_sidebar', 'format_mooin4'),
         ''
@@ -72,33 +100,8 @@ if ($ADMIN->fulltree) {
         1
     ));
 
-
-    // Add a headline "Include in Navigation"
-    $settings->add(new admin_setting_heading(
-        'format_mooin4/global_tile_visibility',
-        get_string('global_tile_visibility', 'format_mooin4'),
-        ''
-    ));
-
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/toggle_global_badge_visibility',
-        new lang_string('toggle_global_badge_visibility', 'format_mooin4'), "",
-        1
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/toggle_global_certificate_visibility',
-        new lang_string('toggle_global_certificate_visibility', 'format_mooin4'), "",
-        1
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/toggle_global_discussion_visibility',
-        new lang_string('toggle_global_discussion_visibility', 'format_mooin4'),"",
-        1
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/toggle_global_userlist_visibility',
-        new lang_string('toggle_global_userlist_visibility', 'format_mooin4'),"",
-        1
-    ));
-   
 }
+
+if (isset($PAGE)) {
+        $PAGE->requires->js(new moodle_url('/course/format/mooin4/format.js'));
+    }

--- a/settings.php
+++ b/settings.php
@@ -33,46 +33,4 @@ if ($ADMIN->fulltree) {
         new lang_string('indentation_help', 'format_mooin4').'<br />'.$link,
         1
     ));
-
-    // Add a headline "Include in Navigation"
-    $settings->add(new admin_setting_heading(
-        'format_mooin4/include_in_navigation',
-        get_string('include_in_sidebar', 'format_mooin4'),
-        ''
-    ));
-
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/news',
-        new lang_string('news', 'format_mooin4'), "",
-        1
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/badges',
-        new lang_string('badges', 'format_mooin4'), "",
-        1
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/certificates',
-        new lang_string('certificates', 'format_mooin4'),"",
-        1
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/coursecompetencies',
-        new lang_string('coursecompetencies', 'tool_lp'),"",
-        0
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/discussions',
-        new lang_string('discussions', 'format_mooin4'),"",
-        1
-    ));
-    $settings->add(new admin_setting_configcheckbox(
-        'format_mooin4/participants',
-        new lang_string('participants', 'format_mooin4'),"",
-        1
-    ));
-
-
-
-
 }

--- a/settings.php
+++ b/settings.php
@@ -73,6 +73,32 @@ if ($ADMIN->fulltree) {
     ));
 
 
+    // Add a headline "Include in Navigation"
+    $settings->add(new admin_setting_heading(
+        'format_mooin4/global_tile_visibility',
+        get_string('global_tile_visibility', 'format_mooin4'),
+        ''
+    ));
 
-
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_badge_visibility',
+        new lang_string('toggle_global_badge_visibility', 'format_mooin4'), "",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_certificate_visibility',
+        new lang_string('toggle_global_certificate_visibility', 'format_mooin4'), "",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_discussion_visibility',
+        new lang_string('toggle_global_discussion_visibility', 'format_mooin4'),"",
+        1
+    ));
+    $settings->add(new admin_setting_configcheckbox(
+        'format_mooin4/toggle_global_userlist_visibility',
+        new lang_string('toggle_global_userlist_visibility', 'format_mooin4'),"",
+        1
+    ));
+   
 }

--- a/templates/local/content/coursefrontpage.mustache
+++ b/templates/local/content/coursefrontpage.mustache
@@ -21,10 +21,12 @@ Example context (json):
                 {{> format_mooin4/local/content/frontpage/header }}
             {{/header}}
             <div class="mobile-bg">
-                {{#news_section}}
-                {{> format_mooin4/local/content/frontpage/news_section }}                
-                {{/news_section}}
-                
+                {{#newssection_visibility}}
+                    {{#news_section}}
+                    {{> format_mooin4/local/content/frontpage/news_section }}                
+                    {{/news_section}}
+                {{/newssection_visibility}}
+                {{#progressbar_visibility}}
                 {{#courseprogress}}
                     {{> format_mooin4/local/content/frontpage/courseprogress }}
                 {{/courseprogress}}

--- a/templates/local/content/coursefrontpage.mustache
+++ b/templates/local/content/coursefrontpage.mustache
@@ -41,8 +41,13 @@ Example context (json):
             </div>
             
         </div>
-        <div class="coursefrontpage__side d-none d-lg-flex">
-            {{^badge_cert_hide}}
+        {{#hide_coursefrontpage_side}}
+            <div class="hide-block">
+        {{/hide_coursefrontpage_side}}
+        {{^hide_coursefrontpage_side}}
+            <div class="coursefrontpage__side d-none d-lg-flex">
+        {{/hide_coursefrontpage_side}}            
+        {{^badge_cert_hide}}
                 {{> format_mooin4/local/content/frontpage/badges_and_certificates }}
             {{/badge_cert_hide}}
             {{> format_mooin4/local/content/frontpage/community }}

--- a/templates/local/content/coursefrontpage.mustache
+++ b/templates/local/content/coursefrontpage.mustache
@@ -42,7 +42,9 @@ Example context (json):
             
         </div>
         <div class="coursefrontpage__side d-none d-lg-flex">
-            {{> format_mooin4/local/content/frontpage/badges_and_certificates }}
+            {{^badge_cert_hide}}
+                {{> format_mooin4/local/content/frontpage/badges_and_certificates }}
+            {{/badge_cert_hide}}
             {{> format_mooin4/local/content/frontpage/community }}
         </div> 
     </div>

--- a/templates/local/content/coursefrontpage.mustache
+++ b/templates/local/content/coursefrontpage.mustache
@@ -27,10 +27,11 @@ Example context (json):
                     {{/news_section}}
                 {{/newssection_visibility}}
                 {{#progressbar_visibility}}
-                {{#courseprogress}}
-                    {{> format_mooin4/local/content/frontpage/courseprogress }}
-                {{/courseprogress}}
-                <div class="seperator"></div>
+                    {{#courseprogress}}
+                        {{> format_mooin4/local/content/frontpage/courseprogress }}
+                    {{/courseprogress}}
+                    <div class="seperator"></div>
+                {{/progressbar_visibility}}
                 {{> format_mooin4/local/content/frontpage/tabletTiles }}
                 {{> format_mooin4/local/content/frontpage/mobileTiles }}
                 {{> format_mooin4/local/content/frontpage/coursetable }}

--- a/templates/local/content/frontpage/badges_and_certificates.mustache
+++ b/templates/local/content/frontpage/badges_and_certificates.mustache
@@ -14,32 +14,34 @@
     
     <div class="tiles-wrapper">
         {{#badges}}
-        <div class="badges-container d-flex flex-column">
-            <div class="d-flex align-items-center">
-                <i class="bi bi-trophy-fill mr-1"></i>
-                <a href="{{{badgesUrl}}}" class="caption">{{#str}} badges, format_mooin4{{/str}}</a>
-                {{#manage_badges_url}}
-                    <a href="{{{manage_badges_url}}}" class="ml-auto"><i class="bi bi-gear-fill"></i></a>
-                {{/manage_badges_url}}
+            {{#badge_visibility}}
+            <div class="badges-container d-flex flex-column">
+                <div class="d-flex align-items-center">
+                    <i class="bi bi-trophy-fill mr-1"></i>
+                    <a href="{{{badgesUrl}}}" class="caption">{{#str}} badges, format_mooin4{{/str}}</a>
+                    {{#manage_badges_url}}
+                        <a href="{{{manage_badges_url}}}" class="ml-auto"><i class="bi bi-gear-fill"></i></a>
+                    {{/manage_badges_url}}
+                </div>
+                <div class="d-flex align-items-center mt-3 mb-3">
+                {{#badgesList}}
+                    {{{badgesList}}}
+                    {{#otherBadges}}
+                        <span class="text-nowrap pr-1">+{{otherBadges}}</span>
+                    {{/otherBadges}}
+                {{/badgesList}}
+                {{^badgesList}}
+                <div class="no-badges-container">
+                    <div class="no-badges-img"></div>
+                    <span class="blue-info-text">{{#str}} no_badges_image_text, format_mooin4{{/str}}</span>
+                </div>
+                {{/badgesList}}
+                </div>
+                <div class="all-badges-link mt-auto">
+                    <a href="{{{badgesUrl}}}" class="ml-auto">{{#str}} show_all_infos, format_mooin4{{/str}}</a>
+                </div>
             </div>
-            <div class="d-flex align-items-center mt-3 mb-3">
-            {{#badgesList}}
-                {{{badgesList}}}
-                {{#otherBadges}}
-                    <span class="text-nowrap pr-1">+{{otherBadges}}</span>
-                {{/otherBadges}}
-            {{/badgesList}}
-            {{^badgesList}}
-            <div class="no-badges-container">
-                <div class="no-badges-img"></div>
-                <span class="blue-info-text">{{#str}} no_badges_image_text, format_mooin4{{/str}}</span>
-            </div>
-            {{/badgesList}}
-            </div>
-            <div class="all-badges-link mt-auto">
-                <a href="{{{badgesUrl}}}" class="ml-auto">{{#str}} show_all_infos, format_mooin4{{/str}}</a>
-            </div>
-        </div>
+            {{/badge_visibility}}
         {{/badges}}
         
 

--- a/templates/local/content/frontpage/badges_and_certificates.mustache
+++ b/templates/local/content/frontpage/badges_and_certificates.mustache
@@ -10,7 +10,15 @@
 }}
 
 <div class="coursefrontpage__badges-certificates">
-    <h2>{{#str}} badges_certificates, format_mooin4 {{/str}}</h2>
+    {{^certificate_visibility}}
+        <h2>{{#str}} only_badges, format_mooin4 {{/str}}</h2>
+    {{/certificate_visibility}}
+    {{^badge_visibility}}
+        <h2>{{#str}} only_certificates, format_mooin4 {{/str}}</h2>
+    {{/badge_visibility}}
+    {{#badge_cert_visibility}}
+        <h2>{{#str}} badges_certificates, format_mooin4 {{/str}}</h2>
+    {{/badge_cert_visibility}}
     
     <div class="tiles-wrapper">
         {{#badges}}
@@ -46,35 +54,37 @@
         
 
         {{#certificates}}
-        <div class="certificates-container">
-            <div class="d-flex align-items-center">
-                <i class="bi bi-award-fill"></i>
-                <a href="{{{certificatesUrl}}}" class="caption">{{#str}} certificates, format_mooin4{{/str}}</a>
-                {{#has_capability}}
-                <button type="button" class="btn info-tip ml-auto p-0" data-toggle="tooltip" data-placement="top"
-                    title=" {{#str}} certificates_tooltip, format_mooin4 {{/str}}">
-                    <span class="bi bi-info-circle-fill"></span>
-                </button>
-                {{/has_capability}}
-            </div>
-            <div class="mt-3 mb-3 d-flex align-items-center">
-            {{#coursecertificates}}
-                {{{coursecertificates}}}
-                {{#othercertificates}}
-                <span class="text-nowrap pr-1">+{{{othercertificates}}}</span>
-                {{/othercertificates}}
-            {{/coursecertificates}}
-            {{^coursecertificates}}
-                <div class="no-certificates-container">
-                    <div class="no-certificates-img"></div>
-                    <span class="blue-info-text">{{#str}} no_certificates_image_text, format_mooin4{{/str}}</span>
+        {{#certificate_visibility}}
+            <div class="certificates-container">
+                <div class="d-flex align-items-center">
+                    <i class="bi bi-award-fill"></i>
+                    <a href="{{{certificatesUrl}}}" class="caption">{{#str}} certificates, format_mooin4{{/str}}</a>
+                    {{#has_capability}}
+                    <button type="button" class="btn info-tip ml-auto p-0" data-toggle="tooltip" data-placement="top"
+                        title=" {{#str}} certificates_tooltip, format_mooin4 {{/str}}">
+                        <span class="bi bi-info-circle-fill"></span>
+                    </button>
+                    {{/has_capability}}
                 </div>
-            {{/coursecertificates}}
+                <div class="mt-3 mb-3 d-flex align-items-center">
+                {{#coursecertificates}}
+                    {{{coursecertificates}}}
+                    {{#othercertificates}}
+                    <span class="text-nowrap pr-1">+{{{othercertificates}}}</span>
+                    {{/othercertificates}}
+                {{/coursecertificates}}
+                {{^coursecertificates}}
+                    <div class="no-certificates-container">
+                        <div class="no-certificates-img"></div>
+                        <span class="blue-info-text">{{#str}} no_certificates_image_text, format_mooin4{{/str}}</span>
+                    </div>
+                {{/coursecertificates}}
+                </div>
+                <div class="all-badges-link">
+                    <a href="{{{certificatesUrl}}}" class="ml-auto">{{#str}} show_all_infos, format_mooin4{{/str}}</a>
+                </div>
             </div>
-            <div class="all-badges-link">
-                <a href="{{{certificatesUrl}}}" class="ml-auto">{{#str}} show_all_infos, format_mooin4{{/str}}</a>
-            </div>
-        </div>
+        {{/certificate_visibility}}
         {{/certificates}}
     </div>
 </div>

--- a/templates/local/content/frontpage/community.mustache
+++ b/templates/local/content/frontpage/community.mustache
@@ -24,82 +24,86 @@
     {{#previewPost}}
     {{#discussion_url}}
     <span class="unread-info mb-3 d-inline-block">
-        {{#no_new_news}}
-            0 {{#str}} unread_discussions, format_mooin4 {{/str}} <a href="{{{all_discussions_url}}}"> {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
-        {{/no_new_news}}
-        {{^no_new_news}}
-            {{#one_new_news}}
-                <a href="{{{all_discussions_url}}}"><span class="notification-badge mr-1">{{{unreadNewsNumber}}}</span>{{#str}} unread_discussions_single, format_mooin4 {{/str}} {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
-            {{/one_new_news}}
-            {{^one_new_news}}
-                <a href="{{{all_discussions_url}}}"><span class="notification-badge mr-1">{{{unreadNewsNumber}}}</span>{{#str}} unread_discussions, format_mooin4 {{/str}} {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
-            {{/one_new_news}}
-        {{/no_new_news}}
+        {{#discussion_visibility}}
+            {{#no_new_news}}
+                0 {{#str}} unread_discussions, format_mooin4 {{/str}} <a href="{{{all_discussions_url}}}"> {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
+            {{/no_new_news}}
+            {{^no_new_news}}
+                {{#one_new_news}}
+                    <a href="{{{all_discussions_url}}}"><span class="notification-badge mr-1">{{{unreadNewsNumber}}}</span>{{#str}} unread_discussions_single, format_mooin4 {{/str}} {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
+                {{/one_new_news}}
+                {{^one_new_news}}
+                    <a href="{{{all_discussions_url}}}"><span class="notification-badge mr-1">{{{unreadNewsNumber}}}</span>{{#str}} unread_discussions, format_mooin4 {{/str}} {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
+                {{/one_new_news}}
+            {{/no_new_news}}
+        {{/discussion_visibility}}   
     </span>
     {{/discussion_url}}
      {{/previewPost}}
     
     <div class="tiles-wrapper">
             {{#previewPost}}
-            {{#discussion_url}}
-                <div class="discussion-preview d-flex flex-column">
-                    <div class="d-flex align-items-start">
-                        <span class="chat-icon pr-2">
-                            <i class="bi bi-chat-left"></i>
-                            <i class="bi bi-chat-right-text-fill"></i>
-                        </span>
-                        <span class="caption--sm">
-                            <a href="{{{discussion_url}}}" class="caption caption--sm">{{#str}} latest_post, format_mooin4 {{/str}}</a>
-                            {{#str}} by, format_mooin4 {{/str}}
-                            {{{user_firstname}}} - {{{created_news}}}
-                        </span>
-                        {{#has_capability}}
-                            <button type="button" class="btn info-tip p-0 ml-auto d-none d-sm-block d-lg-none" data-toggle="tooltip" data-placement="top"
-                            title="{{#str}} discussions_tooltip, format_mooin4 {{/str}}">
-                                <span class="bi bi-info-circle-fill"></span>
-                            </button>
-                        {{/has_capability}}
-                    </div>
-                    <div class="news-post-preview">
-                        <div class="pr-1">
-                            {{{user_picture}}}
-                        </div>
-                        <div class="text-truncate">
-                            <span class="news-title">{{{news_title}}}</span>
-                            <span class="news-text">{{{news_text}}}</span>
-                        </div>
-                    </div>
-                    <div class="discussion-link mt-auto">
-                        <a class="" href="{{{discussion_url}}}">{{#str}} discussion_news, format_mooin4 {{/str}}</a>
-                    </div>
-                </div>
-                {{/discussion_url}}
-            
-            {{#no_discussions_available}}
-                <div class="discussion-preview d-flex flex-column d-md-flex d-lg-none justify-content-between">
-                    <div class="d-flex align-items-center">
-                        <i class="bi bi-newspaper mr-2"></i>
-                        <span class="d-flex w-100">
-                            <a href="{{{all_discussions_url}}}" class="caption"> {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
+            {{#discussion_visibility}}
+                {{#discussion_url}}
+                    <div class="discussion-preview d-flex flex-column">
+                        <div class="d-flex align-items-start">
+                            <span class="chat-icon pr-2">
+                                <i class="bi bi-chat-left"></i>
+                                <i class="bi bi-chat-right-text-fill"></i>
+                            </span>
+                            <span class="caption--sm">
+                                <a href="{{{discussion_url}}}" class="caption caption--sm">{{#str}} latest_post, format_mooin4 {{/str}}</a>
+                                {{#str}} by, format_mooin4 {{/str}}
+                                {{{user_firstname}}} - {{{created_news}}}
+                            </span>
                             {{#has_capability}}
-                                <button type="button" class="btn info-tip ml-auto p-0" data-toggle="tooltip" data-placement="top"
-                                    title=" {{#str}} certificates_tooltip, format_mooin4 {{/str}}">
+                                <button type="button" class="btn info-tip p-0 ml-auto d-none d-sm-block d-lg-none" data-toggle="tooltip" data-placement="top"
+                                title="{{#str}} discussions_tooltip, format_mooin4 {{/str}}">
                                     <span class="bi bi-info-circle-fill"></span>
                                 </button>
                             {{/has_capability}}
-                        </span>
+                        </div>
+                        <div class="news-post-preview">
+                            <div class="pr-1">
+                                {{{user_picture}}}
+                            </div>
+                            <div class="text-truncate">
+                                <span class="news-title">{{{news_title}}}</span>
+                                <span class="news-text">{{{news_text}}}</span>
+                            </div>
+                        </div>
+                        <div class="discussion-link mt-auto">
+                            <a class="" href="{{{discussion_url}}}">{{#str}} discussion_news, format_mooin4 {{/str}}</a>
+                        </div>
                     </div>
-                    <div class="d-flex">
-                        <div class="no-discussion-img"></div>
-                        <span class="blue-info-text">{{#str}} no_contributions_available, format_mooin4 {{/str}}</span>
+                    {{/discussion_url}}
+                
+                {{#no_discussions_available}}
+                    <div class="discussion-preview d-flex flex-column d-md-flex d-lg-none justify-content-between">
+                        <div class="d-flex align-items-center">
+                            <i class="bi bi-newspaper mr-2"></i>
+                            <span class="d-flex w-100">
+                                <a href="{{{all_discussions_url}}}" class="caption"> {{#str}} discussion_forum, format_mooin4 {{/str}}</a>
+                                {{#has_capability}}
+                                    <button type="button" class="btn info-tip ml-auto p-0" data-toggle="tooltip" data-placement="top"
+                                        title=" {{#str}} certificates_tooltip, format_mooin4 {{/str}}">
+                                        <span class="bi bi-info-circle-fill"></span>
+                                    </button>
+                                {{/has_capability}}
+                            </span>
+                        </div>
+                        <div class="d-flex">
+                            <div class="no-discussion-img"></div>
+                            <span class="blue-info-text">{{#str}} no_contributions_available, format_mooin4 {{/str}}</span>
+                        </div>
+                        
+                        
+                        <div class="discussion-link">
+                            <a class="" href="{{{all_discussions_url}}}">{{#str}} show_all_forums, format_mooin4 {{/str}}</a>
+                        </div>
                     </div>
-                    
-                    
-                    <div class="discussion-link">
-                        <a class="" href="{{{all_discussions_url}}}">{{#str}} show_all_forums, format_mooin4 {{/str}}</a>
-                    </div>
-                </div>
-            {{/no_discussions_available}}
+                {{/no_discussions_available}}
+            {{/discussion_visibility}}
             {{/previewPost}}
         {{/discussions}}
         {{#participants}}

--- a/templates/local/content/frontpage/community.mustache
+++ b/templates/local/content/frontpage/community.mustache
@@ -9,7 +9,12 @@
     }
 }}
 
-<div class="coursefrontpage__community d-flex flex-column">
+{{#community_visibility}}
+    <div class="coursefrontpage__community d-flex flex-column">
+{{/community_visibility}}
+{{^community_visibility}}
+    <div class="coursefrontpage__community flex-column hide-block">
+{{/community_visibility}}
     <span class="d-flex">
         <h2>{{#str}} community, format_mooin4 {{/str}}</h2>
         {{#has_capability}}
@@ -107,66 +112,68 @@
             {{/previewPost}}
         {{/discussions}}
         {{#participants}}
-            <div class="participants-container d-flex flex-column">
-                {{#has_capability}}
-                    {{#userCardList}}
-                        <span>
-                            <i class="bi bi-people-fill"></i>
-                            <a href="{{{participantsUrl}}}" class="caption">{{#str}} user_card_title, format_mooin4 {{/str}}</a>  
-                        </span>
-                            <div class="d-flex flex-column ml-4">
-                                <span>
-                                    <span class="font-weight-bold">
+            {{#userlist_visibility}}
+                <div class="participants-container d-flex flex-column">
+                    {{#has_capability}}
+                        {{#userCardList}}
+                            <span>
+                                <i class="bi bi-people-fill"></i>
+                                <a href="{{{participantsUrl}}}" class="caption">{{#str}} user_card_title, format_mooin4 {{/str}}</a>  
+                            </span>
+                                <div class="d-flex flex-column ml-4">
+                                    <span>
+                                        <span class="font-weight-bold">
+                                            {{{user_count}}} 
+                                            {{^singleuser}}
+                                                {{#str}} user, format_mooin4 {{/str}}
+                                            {{/singleuser}}
+                                            {{#singleuser}}
+                                                {{#str}} singleuser, format_mooin4 {{/str}}
+                                            {{/singleuser}}
+                                        </span>
+                                        {{^singleuser}}
+                                            {{#str}} in_course, format_mooin4 {{/str}}
+                                        {{/singleuser}}
+                                        {{#singleuser}}
+                                            {{#str}} in_course_sgl, format_mooin4 {{/str}}
+                                        {{/singleuser}}
+                                    </span>
+                                    <span class="font-weight-bold caption--sm"> {{#str}} new_user, format_mooin4 {{/str}} </span>
+                                    <span class="caption--sm">
+                                        {{{user_list}}}
+                                    </span>
+                                </div>
+                                <div class="participants-link mt-auto">
+                                    <a href="{{{participantsUrl}}}">{{#str}} show_all_infos, format_mooin4 {{/str}}</a>
+                                </div>
+                        {{/userCardList}}
+                    {{/has_capability}}
+                    {{^has_capability}}
+                        {{#userCardList}}
+                            <span>
+                                <i class="bi bi-people-fill"></i>
+                                <span class="caption">
+                                    {{#str}} user_card_title, format_mooin4 {{/str}} 
+                                </span>
+                            </span>
+                            <div class="no-participantscap-container">
+                                <div class="no-participantscap-img"></div>
+                                <span class="blue-info-text">
                                         {{{user_count}}} 
                                         {{^singleuser}}
                                             {{#str}} user, format_mooin4 {{/str}}
+                                            {{#str}} in_course, format_mooin4 {{/str}}
                                         {{/singleuser}}
                                         {{#singleuser}}
                                             {{#str}} singleuser, format_mooin4 {{/str}}
+                                            {{#str}} in_course_sgl, format_mooin4 {{/str}}
                                         {{/singleuser}}
-                                    </span>
-                                    {{^singleuser}}
-                                        {{#str}} in_course, format_mooin4 {{/str}}
-                                    {{/singleuser}}
-                                    {{#singleuser}}
-                                        {{#str}} in_course_sgl, format_mooin4 {{/str}}
-                                    {{/singleuser}}
-                                </span>
-                                <span class="font-weight-bold caption--sm"> {{#str}} new_user, format_mooin4 {{/str}} </span>
-                                <span class="caption--sm">
-                                    {{{user_list}}}
                                 </span>
                             </div>
-                            <div class="participants-link mt-auto">
-                                <a href="{{{participantsUrl}}}">{{#str}} show_all_infos, format_mooin4 {{/str}}</a>
-                            </div>
-                    {{/userCardList}}
-                {{/has_capability}}
-                {{^has_capability}}
-                    {{#userCardList}}
-                        <span>
-                            <i class="bi bi-people-fill"></i>
-                            <span class="caption">
-                                {{#str}} user_card_title, format_mooin4 {{/str}} 
-                            </span>
-                        </span>
-                        <div class="no-participantscap-container">
-                            <div class="no-participantscap-img"></div>
-                            <span class="blue-info-text">
-                                    {{{user_count}}} 
-                                    {{^singleuser}}
-                                        {{#str}} user, format_mooin4 {{/str}}
-                                        {{#str}} in_course, format_mooin4 {{/str}}
-                                    {{/singleuser}}
-                                    {{#singleuser}}
-                                        {{#str}} singleuser, format_mooin4 {{/str}}
-                                        {{#str}} in_course_sgl, format_mooin4 {{/str}}
-                                    {{/singleuser}}
-                            </span>
-                        </div>
-                    {{/userCardList}}
-                {{/has_capability}}
-            </div>
+                        {{/userCardList}}
+                    {{/has_capability}}
+                </div>
+            {{/userlist_visibility}}
         {{/participants}}
     </div>
 </div>

--- a/templates/local/content/frontpage/mobileTiles.mustache
+++ b/templates/local/content/frontpage/mobileTiles.mustache
@@ -1,23 +1,35 @@
 
 
 <div class="mobile-tiles d-flex d-sm-none flex-column">
-    <h2>{{#str}} badges_certificates, format_mooin4 {{/str}}</h2>
-    <div class="d-flex badges-certificates-mobile mb-4">
+{{^badge_cert_hide}}
+    {{^certificate_visibility}}
+        <h2>{{#str}} only_badges, format_mooin4 {{/str}}</h2>
+    {{/certificate_visibility}}
+    {{^badge_visibility}}
+        <h2>{{#str}} only_certificates, format_mooin4 {{/str}}</h2>
+    {{/badge_visibility}}
+    {{#badge_cert_visibility}}
+        <h2>{{#str}} badges_certificates, format_mooin4 {{/str}}</h2>
+    {{/badge_cert_visibility}}    <div class="d-flex badges-certificates-mobile mb-4">
     {{#badges}}
-        <a href="{{{badgesUrl}}}" class="mooin4-btn">
-            <i class="bi bi-trophy-fill mr-1"></i>
-            {{#str}} course_badges, format_mooin4{{/str}}
-        </a>
+        {{#badge_visibility}}
+            <a href="{{{badgesUrl}}}" class="mooin4-btn">
+                <i class="bi bi-trophy-fill mr-1"></i>
+                {{#str}} course_badges, format_mooin4{{/str}}
+            </a>
+        {{/badge_visibility}}
     {{/badges}}
     {{#certificates}}
-        <a href="{{{certificatesUrl}}}" class="mooin4-btn">
-            <i class="bi bi-award-fill mr-1"></i>
-            {{#str}} my_certificate, format_mooin4{{/str}}
-        </a>
+        {{#certificate_visibility}}
+            <a href="{{{certificatesUrl}}}" class="mooin4-btn">
+                <i class="bi bi-award-fill mr-1"></i>
+                {{#str}} my_certificate, format_mooin4{{/str}}
+            </a>
+        {{/certificate_visibility}}
     {{/certificates}}
     </div>
     <div class="seperator m-0 mb-4"></div>
-
+{{/badge_cert_hide}}
 
 
     <h2>{{#str}} community, format_mooin4 {{/str}}</h2>

--- a/templates/local/content/frontpage/mobileTiles.mustache
+++ b/templates/local/content/frontpage/mobileTiles.mustache
@@ -31,31 +31,34 @@
     <div class="seperator m-0 mb-4"></div>
 {{/badge_cert_hide}}
 
-
-    <h2>{{#str}} community, format_mooin4 {{/str}}</h2>
-    <div class="d-flex badges-certificates-mobile mb-4">
-    {{#discussions}}
-        {{#discussion_visibility}}
-            <a href="{{{all_discussions_url}}}" class="mooin4-btn">
-                <span class="chat-icon pr-2 position-relative">
-                    <i class="bi bi-chat-left"></i>
-                    <i class="bi bi-chat-right-text-fill"></i>
-                    {{^no_new_news}}
-                    <span class="notification-badge notification-badge--mobile position-absolute">{{{unreadNewsNumber}}}</span>
-                    {{/no_new_news}}
-                </span>
-                
-                {{#str}} forums, format_mooin4{{/str}}
-            </a>
-        {{/discussion_visibility}}
-    {{/discussions}}
-    
-    {{#participants}}
-        <a href="{{{participantsUrl}}}" class="mooin4-btn">
-            <i class="bi bi-people-fill mr-1"></i>
-            {{#str}} participants, format_mooin4{{/str}}
-        </a>
-    {{/participants}}
-    </div>
-    <div class="seperator m-0"></div>
+    {{#community_visibility}}
+        <h2>{{#str}} community, format_mooin4 {{/str}}</h2>
+        <div class="d-flex badges-certificates-mobile mb-4">
+        {{#discussions}}
+            {{#discussion_visibility}}
+                <a href="{{{all_discussions_url}}}" class="mooin4-btn">
+                    <span class="chat-icon pr-2 position-relative">
+                        <i class="bi bi-chat-left"></i>
+                        <i class="bi bi-chat-right-text-fill"></i>
+                        {{^no_new_news}}
+                        <span class="notification-badge notification-badge--mobile position-absolute">{{{unreadNewsNumber}}}</span>
+                        {{/no_new_news}}
+                    </span>
+                    
+                    {{#str}} forums, format_mooin4{{/str}}
+                </a>
+            {{/discussion_visibility}}
+        {{/discussions}}
+        
+        {{#participants}}
+            {{#userlist_visibility}}
+                <a href="{{{participantsUrl}}}" class="mooin4-btn">
+                    <i class="bi bi-people-fill mr-1"></i>
+                    {{#str}} participants, format_mooin4{{/str}}
+                </a>
+            {{/userlist_visibility}}
+        {{/participants}}
+        </div>
+        <div class="seperator m-0"></div>
+    {{/community_visibility}}
 </div>

--- a/templates/local/content/frontpage/mobileTiles.mustache
+++ b/templates/local/content/frontpage/mobileTiles.mustache
@@ -1,39 +1,38 @@
 
-
 <div class="mobile-tiles d-flex d-sm-none flex-column">
-{{^badge_cert_hide}}
-    {{^certificate_visibility}}
-        <h2>{{#str}} only_badges, format_mooin4 {{/str}}</h2>
-    {{/certificate_visibility}}
-    {{^badge_visibility}}
-        <h2>{{#str}} only_certificates, format_mooin4 {{/str}}</h2>
-    {{/badge_visibility}}
-    {{#badge_cert_visibility}}
-        <h2>{{#str}} badges_certificates, format_mooin4 {{/str}}</h2>
-    {{/badge_cert_visibility}}    <div class="d-flex badges-certificates-mobile mb-4">
-    {{#badges}}
-        {{#badge_visibility}}
-            <a href="{{{badgesUrl}}}" class="mooin4-btn">
-                <i class="bi bi-trophy-fill mr-1"></i>
-                {{#str}} course_badges, format_mooin4{{/str}}
-            </a>
-        {{/badge_visibility}}
-    {{/badges}}
-    {{#certificates}}
-        {{#certificate_visibility}}
-            <a href="{{{certificatesUrl}}}" class="mooin4-btn">
-                <i class="bi bi-award-fill mr-1"></i>
-                {{#str}} my_certificate, format_mooin4{{/str}}
-            </a>
+    {{^badge_cert_hide}}
+        {{^certificate_visibility}}
+            <h2>{{#str}} only_badges, format_mooin4 {{/str}}</h2>
         {{/certificate_visibility}}
-    {{/certificates}}
+        {{^badge_visibility}}
+            <h2>{{#str}} only_certificates, format_mooin4 {{/str}}</h2>
+        {{/badge_visibility}}
+        {{#badge_cert_visibility}}
+            <h2>{{#str}} badges_certificates, format_mooin4 {{/str}}</h2>
+        {{/badge_cert_visibility}}    <div class="d-flex badges-certificates-mobile mb-4">
+        {{#badges}}
+            {{#badge_visibility}}
+                <a href="{{{badgesUrl}}}" class="mooin4-btn">
+                    <i class="bi bi-trophy-fill mr-1"></i>
+                    {{#str}} course_badges, format_mooin4{{/str}}
+                </a>
+            {{/badge_visibility}}
+        {{/badges}}
+        {{#certificates}}
+            {{#certificate_visibility}}
+                <a href="{{{certificatesUrl}}}" class="mooin4-btn">
+                    <i class="bi bi-award-fill mr-1"></i>
+                    {{#str}} my_certificate, format_mooin4{{/str}}
+                </a>
+            {{/certificate_visibility}}
+        {{/certificates}}
     </div>
     <div class="seperator m-0 mb-4"></div>
 {{/badge_cert_hide}}
 
-    {{#community_visibility}}
-        <h2>{{#str}} community, format_mooin4 {{/str}}</h2>
-        <div class="d-flex badges-certificates-mobile mb-4">
+{{#community_visibility}}
+    <h2>{{#str}} community, format_mooin4 {{/str}}</h2>
+    <div class="d-flex badges-certificates-mobile mb-4">
         {{#discussions}}
             {{#discussion_visibility}}
                 <a href="{{{all_discussions_url}}}" class="mooin4-btn">

--- a/templates/local/content/frontpage/mobileTiles.mustache
+++ b/templates/local/content/frontpage/mobileTiles.mustache
@@ -23,18 +23,19 @@
     <h2>{{#str}} community, format_mooin4 {{/str}}</h2>
     <div class="d-flex badges-certificates-mobile mb-4">
     {{#discussions}}
-        <a href="{{{all_discussions_url}}}" class="mooin4-btn">
-            <span class="chat-icon pr-2 position-relative">
-                <i class="bi bi-chat-left"></i>
-                <i class="bi bi-chat-right-text-fill"></i>
-                {{^no_new_news}}
-                <span class="notification-badge notification-badge--mobile position-absolute">{{{unreadNewsNumber}}}</span>
-                {{/no_new_news}}
-            </span>
-            
-            {{#str}} forums, format_mooin4{{/str}}
-        </a>
-        
+        {{#discussion_visibility}}
+            <a href="{{{all_discussions_url}}}" class="mooin4-btn">
+                <span class="chat-icon pr-2 position-relative">
+                    <i class="bi bi-chat-left"></i>
+                    <i class="bi bi-chat-right-text-fill"></i>
+                    {{^no_new_news}}
+                    <span class="notification-badge notification-badge--mobile position-absolute">{{{unreadNewsNumber}}}</span>
+                    {{/no_new_news}}
+                </span>
+                
+                {{#str}} forums, format_mooin4{{/str}}
+            </a>
+        {{/discussion_visibility}}
     {{/discussions}}
     
     {{#participants}}

--- a/templates/local/content/frontpage/tabletTiles.mustache
+++ b/templates/local/content/frontpage/tabletTiles.mustache
@@ -9,10 +9,14 @@
     }
 }}
 
-<div class="tablet-tiles d-none d-sm-flex d-lg-none flex-column">
-    {{> format_mooin4/local/content/frontpage/badges_and_certificates }}
-    <div class="seperator"></div>
-    {{> format_mooin4/local/content/frontpage/community }}
-    
+<div id="tablet-badge-cert">
+    {{^badge_cert_hide}}
+    <div class="tablet-tiles d-none d-sm-flex d-lg-none flex-column">
+        {{> format_mooin4/local/content/frontpage/badges_and_certificates }}
+        <div class="seperator"></div>
+        {{> format_mooin4/local/content/frontpage/community }}
+        
+    </div>
+    <div class="seperator d-none d-sm-flex d-lg-none"></div>
+{{/badge_cert_hide}}
 </div>
-<div class="seperator d-none d-sm-flex d-lg-none"></div>

--- a/templates/local/courseindex/drawer.mustache
+++ b/templates/local/courseindex/drawer.mustache
@@ -45,13 +45,15 @@
         {{#coursecompetencies}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-radar"></i> {{#str}} coursecompetencies, tool_lp {{/str}}</a>
         {{/coursecompetencies}}
-        {{#discussions}}
-            <a href="{{url}}" class="{{#active}}active{{/active}}"><span class="chat-icon pr-2">
-                <i class="bi bi-chat-left"></i>
-                <i class="bi bi-chat-right-text-fill"></i>
-                </span>{{#str}} forums, format_mooin4 {{/str}}
-            </a>
-        {{/discussions}}
+        {{#discussion_visibility}}
+            {{#discussions}}
+                <a href="{{url}}" class="{{#active}}active{{/active}}"><span class="chat-icon pr-2">
+                    <i class="bi bi-chat-left"></i>
+                    <i class="bi bi-chat-right-text-fill"></i>
+                    </span>{{#str}} forums, format_mooin4 {{/str}}
+                </a>
+            {{/discussions}}
+        {{/discussion_visibility}}
         {{#participants}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-people-fill"></i> {{#str}} participants, format_mooin4 {{/str}}</a>
         {{/participants}}

--- a/templates/local/courseindex/drawer.mustache
+++ b/templates/local/courseindex/drawer.mustache
@@ -31,31 +31,25 @@
         {{#overview}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-signpost-2-fill"></i> {{#str}} course_overview, format_mooin4 {{/str}}</a>
         {{/overview}}
-        {{#newssection_visibility}}
-            {{#newsforum}}
-                <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-newspaper"></i> {{#str}} news, format_mooin4 {{/str}}</a>
-            {{/newsforum}}
-        {{/newssection_visibility}}
-        {{#badge_visibility}}
-            {{#badges}}
-                <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-trophy-fill"></i> {{#str}} badges, format_mooin4 {{/str}}</a>
-            {{/badges}}
-        {{/badge_visibility}}
+        {{#newsforum}}
+            <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-newspaper"></i> {{#str}} news, format_mooin4 {{/str}}</a>
+        {{/newsforum}}
+        {{#badges}}
+            <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-trophy-fill"></i> {{#str}} badges, format_mooin4 {{/str}}</a>
+        {{/badges}}
         {{#certificates}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-award-fill"></i> {{#str}} certificates, format_mooin4 {{/str}}</a>
         {{/certificates}}
         {{#coursecompetencies}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-radar"></i> {{#str}} coursecompetencies, tool_lp {{/str}}</a>
         {{/coursecompetencies}}
-        {{#discussion_visibility}}
-            {{#discussions}}
-                <a href="{{url}}" class="{{#active}}active{{/active}}"><span class="chat-icon pr-2">
-                    <i class="bi bi-chat-left"></i>
-                    <i class="bi bi-chat-right-text-fill"></i>
-                    </span>{{#str}} forums, format_mooin4 {{/str}}
-                </a>
+        {{#discussions}}
+            <a href="{{url}}" class="{{#active}}active{{/active}}"><span class="chat-icon pr-2">
+                <i class="bi bi-chat-left"></i>
+                <i class="bi bi-chat-right-text-fill"></i>
+                </span>{{#str}} forums, format_mooin4 {{/str}}
+            </a>
             {{/discussions}}
-        {{/discussion_visibility}}
         {{#participants}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-people-fill"></i> {{#str}} participants, format_mooin4 {{/str}}</a>
         {{/participants}}

--- a/templates/local/courseindex/drawer.mustache
+++ b/templates/local/courseindex/drawer.mustache
@@ -31,9 +31,11 @@
         {{#overview}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-signpost-2-fill"></i> {{#str}} course_overview, format_mooin4 {{/str}}</a>
         {{/overview}}
-        {{#newsforum}}
-            <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-newspaper"></i> {{#str}} news, format_mooin4 {{/str}}</a>
-        {{/newsforum}}
+        {{#newssection_visibility}}
+            {{#newsforum}}
+                <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-newspaper"></i> {{#str}} news, format_mooin4 {{/str}}</a>
+            {{/newsforum}}
+        {{/newssection_visibility}}
         {{#badges}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-trophy-fill"></i> {{#str}} badges, format_mooin4 {{/str}}</a>
         {{/badges}}

--- a/templates/local/courseindex/drawer.mustache
+++ b/templates/local/courseindex/drawer.mustache
@@ -36,9 +36,11 @@
                 <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-newspaper"></i> {{#str}} news, format_mooin4 {{/str}}</a>
             {{/newsforum}}
         {{/newssection_visibility}}
-        {{#badges}}
-            <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-trophy-fill"></i> {{#str}} badges, format_mooin4 {{/str}}</a>
-        {{/badges}}
+        {{#badge_visibility}}
+            {{#badges}}
+                <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-trophy-fill"></i> {{#str}} badges, format_mooin4 {{/str}}</a>
+            {{/badges}}
+        {{/badge_visibility}}
         {{#certificates}}
             <a href="{{url}}" class="{{#active}}active{{/active}}"><i class="bi bi-award-fill"></i> {{#str}} certificates, format_mooin4 {{/str}}</a>
         {{/certificates}}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024111300;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024111301;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 'v4.4.'; 
 $plugin->requires  = 2022111800;        // Requires this Moodle version.
 $plugin->component = 'format_mooin4';    // Full name of the plugin (used for diagnostics).

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024111301;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024111300;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 'v4.4.'; 
 $plugin->requires  = 2022111800;        // Requires this Moodle version.
 $plugin->component = 'format_mooin4';    // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Es gibt ein globales Menü, hier können folgende globale Änderugen vorgenommen werden unter /admin/settings.php?section=formatsettingmooin4: 
- Links im Kursindex anzeigen
- mooin-Kacheln global verfügbar (Kursstartseite) -> wenn Option nicht gesetzt ist, ist auch in den Kurseinstellungen diese Option nicht verfügbar 

Folgende Elemente können lokal für jeden Kurs ausgeblendet werden (Kurssettings): 
- Kursindex
- News-Bereich
- Progress Bar
- Badge- und Zertifikate-Kachel (wenn globale Settings das erlauben, ansonsten nicht sichtbar)
- Diskussions- und TN-Kachel (wenn globale Settings das erlauben, ansonsten nicht sichtbar)

Tests: 

- [x] mooin_405-Theme aktualisieren
- [x] verschiedene Optionen im globalen Settings unter /admin/settings.php?section=formatsettingmooin4 ein- und ausschalten und schauen, ob im Kurs alles weiterhin gut aussieht und das entsprechende Element ausgeblendet ist
- [ ] in den Kurssettings schauen (entsprechend den globalen Settings), ob die Funktionalität vorhanden/nicht vorhanden ist 
- [x] Optionen in den Kurssettings ein- und ausschalten und schauen, ob im Kurs alles weiterhin gut aussieht und das entsprechende Element ausgeblendet ist