### PR TITLE
Bugfix: prevent renaming of course sections while duplicating non mooin4 courses

### DIFF
--- a/backup/moodle2/restore_format_mooin4_plugin.class.php
+++ b/backup/moodle2/restore_format_mooin4_plugin.class.php
@@ -120,7 +120,7 @@ class restore_format_mooin4_plugin extends restore_format_plugin {
                     $id = $this->get_mappingid('course_section', $section->sectionid);
                     $DB->execute(
                         "UPDATE {course_sections} SET name = ? WHERE course = ? AND id = ?",
-                        [get_string('lesson', 'format_mooin4') .' '.$section->title, $this->step->get_task()->get_courseid(), $id]
+                        [$section->title, $this->step->get_task()->get_courseid(), $id]
                     );
                 }
             }

--- a/backup/moodle2/restore_format_mooin4_plugin.class.php
+++ b/backup/moodle2/restore_format_mooin4_plugin.class.php
@@ -114,13 +114,16 @@ class restore_format_mooin4_plugin extends restore_format_plugin {
 
         $DB->delete_records('files', array('contextid' => $contextid, 'itemid' => $backupinfo->original_course_id));
 
-
-        foreach ($backupinfo->sections as $section) {
-            $id = $this->get_mappingid('course_section', $section->sectionid);
-            $DB->execute(
-                "UPDATE {course_sections} SET name = ? WHERE course = ? AND id = ?",
-                [$section->title, $this->step->get_task()->get_courseid(), $id]
-            );
+        if ($newcourse = $DB->get_record('course', array('id' => $this->step->get_task()->get_courseid()))) {
+            if ($newcourse->format == 'mooin4') {
+                foreach ($backupinfo->sections as $section) {
+                    $id = $this->get_mappingid('course_section', $section->sectionid);
+                    $DB->execute(
+                        "UPDATE {course_sections} SET name = ? WHERE course = ? AND id = ?",
+                        [get_string('lesson', 'format_mooin4') .' '.$section->title, $this->step->get_task()->get_courseid(), $id]
+                    );
+                }
+            }
         }
 
         $DB->delete_records('format_mooin4_chapter', array('chapter' => 1, 'courseid' => $this->step->get_task()->get_courseid()));


### PR DESCRIPTION
Test:
- [x] Plugin Branch mooin_405_bugfix/M41-224 installieren
- [x] Kurs im Themenformat erstellen 
- [x] Kurs duplizieren
- [x] im neuen Kurs prüfen ob die einzelnen Abschnitte immer weiterhin die Überschrift "Neuer Abschnitt" haben
- [x] Kurs im mooin4 Format erstellen
- [x] einzelne Lektionstitel ändern
- [x] Kurs duplizieren
- [x] im neuen Kurs prüfen ob die geänderten Lektionstitel übernommen wurden