### PR TITLE
Bugfix fix/M41-254_check_format_while_restoring

### DIFF
--- a/backup/moodle2/deleterestore_format_mooin4_plugin.class.php
+++ b/backup/moodle2/deleterestore_format_mooin4_plugin.class.php
@@ -101,7 +101,7 @@ class restore_format_mooin4_plugin extends restore_format_plugin {
 
         $data = $this->connectionpoint->get_data();
         $backupinfo = $this->step->get_task()->get_info();
-        if ($backupinfo->original_course_format !== 'topics' || !isset($data['tags']['numsections'])) {
+        if ($backupinfo->original_course_format !== 'mooin4' || !isset($data['tags']['numsections'])) {
             // Backup from another course format or backup file does not even have 'numsections'.
             return;
         }

--- a/backup/moodle2/restore_format_mooin4_plugin.class.php
+++ b/backup/moodle2/restore_format_mooin4_plugin.class.php
@@ -108,6 +108,10 @@ class restore_format_mooin4_plugin extends restore_format_plugin {
 
         $backupinfo = $this->step->get_task()->get_info();
         $contextid = $this->task->get_contextid();
+        
+        if ($backupinfo->original_course_format !== 'mooin4') {
+            return;
+        }
 
         $this->restore_files('headerimagedesktop');
         $this->restore_files('headerimagemobile');


### PR DESCRIPTION
Testen:
- [x] path/to/moodle/admin/settings.php?section=debugging: Debug-Modus auf Developer
- [x] Kurssicherung von Kurs erstellen, der nicht im Mooin Format ist
- [x] Backup als neuen Kurs wiederherstellen
- [x] Log prüfen. Folgender Fehler darf nicht mehr auftreten: PHP Warning:  foreach() argument must be of type array|object, null given in /opt/www/[dev-isy.th-luebeck.de/isy/course/format/mooin4/backup/moodle2/restore_format_mooin4_plugin.class.php](http://dev-isy.th-luebeck.de/isy/course/format/mooin4/backup/moodle2/restore_format_mooin4_plugin.class.php) on line 131