### PR TITLE
Fix mobile and desktop header image visibility.

### DIFF
--- a/templates/local/content/frontpage/header.mustache
+++ b/templates/local/content/frontpage/header.mustache
@@ -14,14 +14,14 @@
     <a href="{{{editheaderlink}}}" class="edit-header-img"><i class="bi bi-gear-fill"></i></a>
     {{/editheaderlink}}
     {{#headerimageURL}}
-        <img src="{{{headerimageURL}}}" alt="" class="header-image">
+        <img src="{{{headerimageURL}}}" alt="" class="header-image d-none d-sm-block">
     {{/headerimageURL}}
     {{^headerimageURL}}
         <div class="desktop-placeholder d-none d-sm-block"></div>
     {{/headerimageURL}}
 
     {{#headerimageURLMobile}}
-        <img src="{{{headerimageURLMobile}}}" alt="" class="header-image">
+        <img src="{{{headerimageURLMobile}}}" alt="" class="header-image d-block d-sm-none">
     {{/headerimageURLMobile}}
     {{^headerimageURLMobile}}
         <div class="mobile-placeholder d-block d-sm-none"></div>


### PR DESCRIPTION
## Tickt Nummer :
[294 und 293](https://isy-thl.atlassian.net/browse/M41-294)
## Problem

Im Frontpage-Header wurden das Desktop- und Mobile-Bild gleichzeitig gerendert.  

## Lösung
In `templates/local/content/frontpage/header.mustache` wurden responsive Bootstrap-Klassen ergänzt:

- Desktop-Bild: `d-none d-sm-block`
- Mobile-Bild: `d-block d-sm-none`

Damit wird auf Mobile nur das Mobile-Headerbild und auf größeren Viewports nur das Desktop-Headerbild angezeigt.

## Geänderte Datei
- `templates/local/content/frontpage/header.mustache`

## Testplan
- [x] Kurs-Frontpage auf Mobile-Breite öffnen.
- [x] Kurs-Frontpage auf Desktop/Tablet öffnen.
