### PR TITLE
Fix section read button visibility with manual completion

### DIFF
--- a/classes/output/courseformat/content/section.php
+++ b/classes/output/courseformat/content/section.php
@@ -127,12 +127,16 @@ class section extends section_base {
         $sectionprogress = utils::get_section_progress($course->id, $this->section->id, $USER->id);
         $data->sectionprogress = $sectionprogress;
 
-        if (!$DB->get_records('course_modules', [
-            'course' => $course->id,
-            'deletioninprogress' => 0,
-            'section' => $this->section->id,
-            'completion' => 2,
-        ])) {
+        // Show the section completion button only when no activity in the section
+        // has completion tracking enabled (manual or automatic).
+        if (!$DB->record_exists_select(
+            'course_modules',
+            'course = :course AND deletioninprogress = 0 AND section = :section AND completion <> 0',
+            [
+                'course' => $course->id,
+                'section' => $this->section->id,
+            ]
+        )) {
             $data->showCompletionButton = true;
         }
         if ($sectionprogress == 100) {


### PR DESCRIPTION

## Zusammenfassung

Ticket Nummer :
[301](https://isy-thl.atlassian.net/browse/M41-301?atlOrigin=eyJpIjoiM2JiY2M0MTIyZDQ4NGU5Nzg2OTg5ODA3ZWI5MjM0MGUiLCJwIjoiaiJ9)
In einem Kursabschnitt wurde der Button **„Seite als gelesen markieren"** angezeigt, obwohl in derselben Section H5P-Aktivitäten mit **manuellem Abschluss** konfiguriert waren. Das führt zu widersprüchlichem Verhalten bei der Abschlusslogik.

---

## Änderung

Die Anzeige-Bedingung für den Section-Button wurde in `classes/output/courseformat/content/section.php` angepasst:

- **Vorher:** Button wurde nur ausgeblendet, wenn Aktivitäten mit (automatischer Abschluss) existieren.
- **Jetzt:** Button wird ausgeblendet, sobald irgendeine Aktivität mit aktivem Completion-Tracking (`completion <> 0`) in der Section vorhanden ist.

---

## Ergebnis

Der Button **„Seite als gelesen markieren"** erscheint nur noch dann, wenn in der Section **keine** Aktivität Abschlussbedingungen nutzt.

---

## Testplan

- [x] Kurs mit öffnen, Section mit Aktivität vorbereiten
- [x] Aktivität auf manuellen Abschluss setzen 
- [x] Kursseite neu laden / Caches leeren
- [x] Prüfen, dass **„Seite als gelesen markieren"** nicht angezeigt wird


---

## Betroffene Datei

- `course/format/mooin4/classes/output/courseformat/content/section.php`