### PR TITLE
Fix forum preview image rendering in mooin4 format.

### DIFF
--- a/classes/local/utils.php
+++ b/classes/local/utils.php
@@ -602,13 +602,14 @@ class utils {
             }
 
             $forumdiscussionurl = new moodle_url('/mod/forum/discuss.php', ['d' => $newsforumpost->discussion]);
+            $formattedmessage = self::format_forum_post_preview($newsforumpost, $cm);
             $templatecontext = [
                 'news_url' => $newsurl,
                 'user_firstname' => $user->firstname,
                 'created_news' => $creatednews,
                 'user_picture' => $OUTPUT->user_picture($user, ['courseid' => $courseid]),
                 'news_title' => $newsforumpost->subject,
-                'news_text' => $newsforumpost->message,
+                'news_text' => $formattedmessage,
                 'discussion_url' => $forumdiscussionurl,
                 'unread_news_number' => $unreadnewsnumber,
             ];
@@ -722,12 +723,13 @@ class utils {
                     $unreadforumnumber = self::count_unread_posts($USER->id, $courseid, false);
 
                     $forumdiscussionurl = new moodle_url('/mod/forum/discuss.php', ['d' => $post->discussion]);
+                    $formattedmessage = self::format_forum_post_preview($post, $cm);
                     $templatecontext = [
                         'user_firstname' => $user->firstname,
                         'created_news' => $creatednews,
                         'user_picture' => $OUTPUT->user_picture($user, ['courseid' => $courseid]),
                         'news_title' => $post->subject,
-                        'news_text' => $post->message,
+                        'news_text' => $formattedmessage,
                         'discussion_url' => $forumdiscussionurl,
                         'unread_news_number' => $unreadforumnumber,
                         'new_news' => false,
@@ -747,6 +749,31 @@ class utils {
         ];
 
         return $templatecontext;
+    }
+
+    /**
+     * Format a forum post message for preview cards.
+     *
+     * @param \stdClass $post The forum post.
+     * @param \stdClass $cm The course module.
+     * @return string
+     */
+    private static function format_forum_post_preview(\stdClass $post, \stdClass $cm): string {
+        $context = \context_module::instance($cm->id);
+        $message = file_rewrite_pluginfile_urls(
+            $post->message,
+            'pluginfile.php',
+            $context->id,
+            'mod_forum',
+            'post',
+            $post->id
+        );
+
+        return format_text($message, $post->messageformat, [
+            'context' => $context,
+            'overflowdiv' => false,
+            'para' => false,
+        ]);
     }
 
 


### PR DESCRIPTION
## Ticketnummer
[298](https://isy-thl.atlassian.net/browse/M41-298?atlOrigin=eyJpIjoiNjNkNzFlNzY5ODg1NDMyMmI4M2U1Yzk2YzQ0YjMxMGQiLCJwIjoiaiJ9)
## Zusammenfassung
- Behebt die Darstellung von Forenbeiträgen in der Vorschau des mooin4-Kursformats, sodass eingebettete Bilder korrekt angezeigt werden.
- Ersetzt die rohe Ausgabe der Foren-Nachricht durch Moodle-konforme Formatierung mit `file_rewrite_pluginfile_urls(...)` und `format_text(...)`.
- Der Fix wurde in beiden Vorschau-Quellen umgesetzt:
  - `get_last_news(...)`
  - `get_last_forum_discussion(...)`

## Warum
In den Vorschaukarten wurde der Foreninhalt bisher roh ausgegeben (`@@PLUGINFILE@@`), dadurch konnten Bild-URLs nicht korrekt aufgelöst werden und Bilder wurden nicht angezeigt.  
Mit den Moodle-APIs für Text- und Dateiverarbeitung werden Pluginfile-URLs korrekt umgeschrieben und der Inhalt im richtigen Modulkontext gerendert.

## Änderungen
- Neue Hilfsmethode `format_forum_post_preview(...)` in `classes/local/utils.php` hinzugefügt.
- Erzeugung des Template-Kontexts angepasst, sodass `news_text` den formatierten Inhalt verwendet.

## Testplan
- [x] Einen Forenbeitrag mit eingebettetem Bild (Anhang) erstellen/aktualisieren.
- [x] Die Frontpage-/Community-Vorschau im mooin4-Format öffnen.
- [x] Prüfen, dass das Bild korrekt angezeigt wird (kein defektes Bildsymbol).
- [x] Prüfen, dass Text und Links weiterhin korrekt gerendert werden.
- [x] Prüfen, dass Beiträge ohne Bilder unverändert funktionieren.